### PR TITLE
Set config.semantic_logger to SemanticLogger

### DIFF
--- a/lib/rails_semantic_logger/railtie.rb
+++ b/lib/rails_semantic_logger/railtie.rb
@@ -14,7 +14,7 @@ module RailsSemanticLogger #:nodoc:
     #        )
     #     end
     #   end
-    config.semantic_logger = ::SemanticLogger::Logger
+    config.semantic_logger = ::SemanticLogger
 
     # Initialize SemanticLogger. In a Rails environment it will automatically
     # insert itself above the configured rails logger to add support for its


### PR DESCRIPTION
This fixes the following exception being thrown when following the instructions to add an appender through `config.semantic_logger`

``` ruby
undefined method `add_appender' for SemanticLogger::Logger:Class (NoMethodError)
```
