### PR TITLE
Be explicit with rails constants in the Engine

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -131,14 +131,14 @@ module RailsSemanticLogger
       Bugsnag.configure { |config| config.logger = SemanticLogger[Bugsnag] } if defined?(Bugsnag)
 
       # Rails Patches
-      require("rails_semantic_logger/extensions/action_cable/tagged_logger_proxy") if defined?(ActionCable)
-      require("rails_semantic_logger/extensions/action_controller/live") if defined?(ActionController::Live)
-      require("rails_semantic_logger/extensions/action_dispatch/debug_exceptions") if defined?(ActionDispatch::DebugExceptions)
-      if defined?(ActionView::StreamingTemplateRenderer::Body)
+      require("rails_semantic_logger/extensions/action_cable/tagged_logger_proxy") if defined?(::ActionCable)
+      require("rails_semantic_logger/extensions/action_controller/live") if defined?(::ActionController::Live)
+      require("rails_semantic_logger/extensions/action_dispatch/debug_exceptions") if defined?(::ActionDispatch::DebugExceptions)
+      if defined?(::ActionView::StreamingTemplateRenderer::Body)
         require("rails_semantic_logger/extensions/action_view/streaming_template_renderer")
       end
       require("rails_semantic_logger/extensions/active_job/logging") if defined?(::ActiveJob)
-      require("rails_semantic_logger/extensions/active_model_serializers/logging") if defined?(ActiveModelSerializers)
+      require("rails_semantic_logger/extensions/active_model_serializers/logging") if defined?(::ActiveModelSerializers)
 
       if config.rails_semantic_logger.semantic
         # Active Job


### PR DESCRIPTION
### Description of changes

We have a rails app where we don't `require "rails"`, but only require a subset of the action*/active* gems to make it work. (It's a very simple app!)

For some of these if you haven't loaded in the Rails gem, then the classes within RailsSemanticLogger cause the `defined?` check to pass and then the code to blow up. Instead change the code here to be explicit in checking these are top level constants, not nested ones inside this gem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
