### PR TITLE
Add missing caching information to logs

### DIFF
--- a/lib/rails_semantic_logger/action_view/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_view/log_subscriber.rb
@@ -40,7 +40,7 @@ module RailsSemanticLogger
           partial: from_rails_root(event.payload[:identifier])
         }
         payload[:within] = from_rails_root(event.payload[:layout]) if event.payload[:layout]
-        payload[:cache]  = payload[:cache_hit] unless event.payload[:cache_hit].nil?
+        payload[:cache]  = event.payload[:cache_hit] unless event.payload[:cache_hit].nil?
         payload[:allocations] = event.allocations if event.respond_to?(:allocations)
 
         logger.measure(
@@ -60,7 +60,7 @@ module RailsSemanticLogger
           template: from_rails_root(identifier),
           count:    event.payload[:count]
         }
-        payload[:cache_hits] = payload[:cache_hits] if payload[:cache_hits]
+        payload[:cache_hits] = event.payload[:cache_hits] if event.payload[:cache_hits]
         payload[:allocations] = event.allocations if event.respond_to?(:allocations)
 
         logger.measure(

--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -32,6 +32,7 @@ module RailsSemanticLogger
         log_payload         = {sql: payload[:sql]}
         log_payload[:binds] = bind_values(payload) unless (payload[:binds] || []).empty?
         log_payload[:allocations] = event.allocations if event.respond_to?(:allocations)
+        log_payload[:cached] = event.payload[:cached]
 
         log = {
           message:  name,


### PR DESCRIPTION
- Fixes a bug where `cache_hit` and `cache_hits` were not correctly added to the payload.

- Adds whether a sql statement came from the query cache or not. This information is shown in regular Rails logs by prepending `CACHE` to the log message:
<img width="895" alt="afbeelding" src="https://user-images.githubusercontent.com/1391851/113845915-46952480-9796-11eb-9613-69958f6129eb.png">




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
