### PR TITLE
Fix notification payload params absence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,3 @@ gem "sqlite3", "~> 1.4.0", platform: :ruby
 group :development do
   gem "rubocop"
 end
-  gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,4 @@ gem "sqlite3", "~> 1.4.0", platform: :ruby
 group :development do
   gem "rubocop"
 end
+  gem 'byebug'

--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -18,7 +18,7 @@ module RailsSemanticLogger
           # According to PR https://github.com/rocketjob/rails_semantic_logger/pull/37/files
           # payload[:params] is not always a Hash.
           payload[:params] = payload[:params].to_unsafe_h unless payload[:params].is_a?(Hash)
-          payload[:params].except!(*INTERNAL_PARAMS)
+          payload[:params] = payload[:params].except(*INTERNAL_PARAMS)
           payload.delete(:params) if payload[:params].empty?
 
           format           = payload[:format]

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -23,7 +23,9 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "get show successfully logs message" do
-    get dashboard_url
+    PayloadCollector.wrap do
+      get dashboard_url
+    end
 
     SemanticLogger.flush
     actual = @mock_logger.message
@@ -39,5 +41,8 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_equal "/dashboard", payload[:path], payload
     assert_equal 200, payload[:status], payload
     assert_equal "OK", payload[:status_message], payload
+
+    payload = PayloadCollector.last
+    assert_equal payload[:params], {"controller"=>"dashboard", "action"=>"show"}
   end
 end

--- a/test/dummy/config/initializers/payload_collector.rb
+++ b/test/dummy/config/initializers/payload_collector.rb
@@ -1,0 +1,4 @@
+ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+  PayloadCollector.append(event.payload)
+end

--- a/test/payload_collector.rb
+++ b/test/payload_collector.rb
@@ -1,0 +1,28 @@
+class PayloadCollector
+  class << self
+    def wrap
+      @store = true
+      yield
+    ensure
+      @store = false
+    end
+
+    def append(payload)
+      data.append(payload) if @store
+    end
+
+    def last
+      data.last
+    end
+
+    def flush
+      @data = []
+    end
+
+    private
+
+    def data
+      @data ||= []
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require "amazing_print"
 
 require "rails/test_help"
 require_relative "mock_logger"
+require_relative "payload_collector"
 
 # Include the complete backtrace?
 Minitest.backtrace_filter = Minitest::BacktraceFilter.new if ENV["BACKTRACE"].present?


### PR DESCRIPTION
### Issue # (if available)

The absence of `payload[:params]` in other active support notification subscribers:

I use [yabeda-rails gem](https://github.com/yabeda-rb/yabeda-rails) to monitor rails application metrics. It is based on the Rails notification instrumentation [here](https://github.com/yabeda-rb/yabeda-rails/blob/master/lib/yabeda/rails.rb#L46-L65).

After rails_semantic_logger plug-in, I've noticed, that [request params in payload](https://github.com/yabeda-rb/yabeda-rails/blob/master/lib/yabeda/rails.rb#L49-L50) become empty. It's because of rails_semantic_logger's callback mofidies original hash, instead of duplication.


### Description of changes

Duplicates local payload params instead of modifying original one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
