### PR TITLE
Fix #128 using request.remote_ip

### DIFF
--- a/lib/rails_semantic_logger/rack/logger.rb
+++ b/lib/rails_semantic_logger/rack/logger.rb
@@ -54,7 +54,7 @@ module RailsSemanticLogger
           payload: {
             method: request.request_method,
             path:   request.filtered_path,
-            ip:     request.ip
+            ip:     request.remote_ip
           }
         }
       end


### PR DESCRIPTION
### Issue # 
https://github.com/rocketjob/rails_semantic_logger/issues/128

### Description of changes
use request.remote_ip instead of request.ip to log the correct IP of the requester


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
