### PR TITLE
Don't use `nil` as payload key.

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -178,7 +178,7 @@ module RailsSemanticLogger
           attr = nil
         end
 
-        [attr&.name, value]
+        [attr&.name || :nil, value]
       end
 
       def type_casted_binds_v5_0_3(binds, casted_binds)

--- a/test/active_record_test.rb
+++ b/test/active_record_test.rb
@@ -90,7 +90,7 @@ class ActiveRecordTest < Minitest::Test
           if Rails.version.to_f >= 6.1
             # Rails 6.1 dropped the bound column name
             # Can be removed once this PR is fixed: https://github.com/rails/rails/pull/41068
-            assert_equal [2, 3], binds[nil], -> { actual.ai }
+            assert_equal [2, 3], binds[:nil], -> { actual.ai }
           else
             assert_equal [2, 3], binds[:age], -> { actual.ai }
           end


### PR DESCRIPTION
Because it is then turned into an empty string key in json and
Elasticsearch refuses to parse it.

Fixes #131