### PR TITLE
Silence method redifinition warnings

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_controller/live.rb
+++ b/lib/rails_semantic_logger/extensions/action_controller/live.rb
@@ -2,6 +2,7 @@
 ActionController::Live
 module ActionController
   module Live
+    undef_method :log_error
     def log_error(exception)
       logger.fatal(exception)
     end

--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -4,6 +4,7 @@ module ActionDispatch
   class DebugExceptions
     private
 
+    undef_method :log_error
     def log_error(_request, wrapper)
       ActiveSupport::Deprecation.silence do
         ActionController::Base.logger.fatal(wrapper.exception)

--- a/lib/rails_semantic_logger/extensions/action_view/streaming_template_renderer.rb
+++ b/lib/rails_semantic_logger/extensions/action_view/streaming_template_renderer.rb
@@ -6,6 +6,7 @@ module ActionView
     class Body
       private
 
+      undef_method :log_error
       def log_error(exception)
         ActionView::Base.logger.fatal(exception)
       end

--- a/lib/rails_semantic_logger/extensions/active_support/logger.rb
+++ b/lib/rails_semantic_logger/extensions/active_support/logger.rb
@@ -3,6 +3,10 @@ require "active_support/logger"
 module ActiveSupport
   # More hacks to try and stop Rails from being it's own worst enemy.
   class Logger
+    class << self
+      undef :logger_outputs_to?, :broadcast
+    end
+
     # Prevent Console from trying to merge loggers
     def self.logger_outputs_to?(*args)
       true


### PR DESCRIPTION
### Issue # (if available)
```
$ RUBYOPT='-w' bundle exec rspec   
…/rails_semantic_logger-4.6.0/lib/rails_semantic_logger/extensions/action_controller/live.rb:2: warning: possibly useless use of :: in void context
…/rails_semantic_logger-4.6.0/lib/rails_semantic_logger/extensions/action_controller/live.rb:5: warning: method redefined; discarding old log_error
…/actionpack-6.1.4/lib/action_controller/metal/live.rb:307: warning: previous definition of log_error was here
…/rails_semantic_logger-4.6.0/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb:2: warning: possibly useless use of :: in void context
…/rails_semantic_logger-4.6.0/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb:7: warning: method redefined; discarding old log_error
…/actionpack-6.1.4/lib/action_dispatch/middleware/debug_exceptions.rb:134: warning: previous definition of log_error was here
…/rails_semantic_logger-4.6.0/lib/rails_semantic_logger/extensions/action_view/streaming_template_renderer.rb:2: warning: possibly useless use of :: in void context
…/rails_semantic_logger-4.6.0/lib/rails_semantic_logger/extensions/action_view/streaming_template_renderer.rb:9: warning: method redefined; discarding old log_error
…/actionview-6.1.4/lib/action_view/renderer/streaming_template_renderer.rb:31: warning: previous definition of log_error was here
```

### Description of changes
Warnings bad, no warnings good.

`possibly useless use of :: in void context` are not fixed, they're caused by first lines like
```ruby
 ActionController::Live
 module ActionController
   module Live
```
AFAIU it's needed to autoload before monkeypatching and according to gemspec `rails >= 3.2` is supported. I don't even remember how autoloading works in 3.2 and not sure if it's possible to use `.on_load` there. 
Since CI tests `>= 5.1` — is `< 5.1` actually supported?
I prefer to either add them to CI (in a separate PR) or bump gemspec requirement. Although it's possible to merge changes with green CI without testing on old rails and see if someone will complain, I guess.

Also could be changed to `ActionController::Live.prepend(LiveMonkeyPatch)`, so autoloading happens and it's not in void context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
