### PR TITLE
Revert "Fixes #83 Also log to stderr when running in a rails console"

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -42,7 +42,7 @@ module RailsSemanticLogger
 
         # Log the location of the query itself.
         if logger.send(:level_index) >= SemanticLogger.backtrace_level_index
-          log[:backtrace] = SemanticLogger::Utils.strip_backtrace(caller)
+          log[:backtrace] = SemanticLogger::Utils.strip_backtrace
         end
 
         logger.debug(log)

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -214,15 +214,6 @@ module RailsSemanticLogger
 
       # Re-open appenders after Spring has forked a process
       Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)
-
-      console do |_app|
-        # Don't use a background thread for logging
-        SemanticLogger.sync!
-        SemanticLogger.add_appender(io: STDERR, formatter: :color)
-
-        # Include method names on log entries in the console
-        SemanticLogger.backtrace_level = SemanticLogger.default_level
-      end
     end
   end
 end

--- a/rails_semantic_logger.gemspec
+++ b/rails_semantic_logger.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
   spec.add_dependency "rack"
   spec.add_dependency "railties", ">= 3.2"
-  spec.add_dependency "semantic_logger", "~> 4.8"
+  spec.add_dependency "semantic_logger", "~> 4.4"
 end


### PR DESCRIPTION
This reverts commit afee72343e099142ffda7a9431d194c6e1744e3b.

### Issue # (if available)

Issue #135

### Description of changes

Reverts automatic injection of a console logger at low log level into Rails consoles. There is no obvious workaround to avoid the added logger since the callback is executed late into the application startup. Users who require that feature can easily replicate the code block in their environment definitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
