### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
+++ b/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
@@ -1,4 +1,4 @@
-ActionCable::Connection::TaggedLoggerProxy
+require "action_cable/connection/tagged_logger_proxy"
 
 module ActionCable
   module Connection

--- a/lib/rails_semantic_logger/extensions/action_controller/live.rb
+++ b/lib/rails_semantic_logger/extensions/action_controller/live.rb
@@ -1,5 +1,6 @@
 # Log actual exceptions, not a string representation
-ActionController::Live
+require "action_controller"
+
 module ActionController
   module Live
     undef_method :log_error

--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -1,5 +1,6 @@
 # Log actual exceptions, not a string representation
-ActionDispatch::DebugExceptions
+require "action_dispatch"
+
 module ActionDispatch
   class DebugExceptions
     private

--- a/lib/rails_semantic_logger/extensions/action_view/streaming_template_renderer.rb
+++ b/lib/rails_semantic_logger/extensions/action_view/streaming_template_renderer.rb
@@ -1,5 +1,5 @@
 # Log actual exceptions, not a string representation
-ActionView::StreamingTemplateRenderer
+require "action_view/renderer/streaming_template_renderer"
 
 module ActionView
   class StreamingTemplateRenderer

--- a/lib/rails_semantic_logger/extensions/active_job/logging.rb
+++ b/lib/rails_semantic_logger/extensions/active_job/logging.rb
@@ -7,6 +7,7 @@ module ActiveJob
 
     private
 
+    undef_method :tag_logger
     def tag_logger(*tags, &block)
       logger.tagged(*tags, &block)
     end

--- a/lib/rails_semantic_logger/extensions/rails/server.rb
+++ b/lib/rails_semantic_logger/extensions/rails/server.rb
@@ -4,7 +4,8 @@ require "rails"
 module Rails
   class Server
     private
-
+    
+    undef_method :log_to_stdout
     def log_to_stdout
       wrapped_app # touch the app so the logger is set up
 

--- a/lib/rails_semantic_logger/extensions/rails/server.rb
+++ b/lib/rails_semantic_logger/extensions/rails/server.rb
@@ -1,5 +1,6 @@
 # Patch the Rails::Server log_to_stdout so that it logs via SemanticLogger
-Rails::Server
+require "rails"
+
 module Rails
   class Server
     private


### PR DESCRIPTION
### Issue # (if available)

Fails in projects with no warning policy, e.g. using `warning` gem with raise on warn. 
Overall warnings are bad.

### Description of changes

1. Eliminate warnings ` warning: possibly useless use of :: in void context` in several files
2. Eliminate method redefinition warning in couple of files

