### PR TITLE
Respect Rails filtered_parameters

### DIFF
--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -17,7 +17,7 @@ module RailsSemanticLogger
 
           # According to PR https://github.com/reidmorrison/rails_semantic_logger/pull/37/files
           # payload[:params] is not always a Hash.
-          payload[:params] = payload[:params].to_unsafe_h unless payload[:params].is_a?(Hash)
+          payload[:params] = payload[:filtered_parameters].to_unsafe_h unless payload[:filtered_parameters].is_a?(Hash)
           payload[:params] = payload[:params].except(*INTERNAL_PARAMS)
           payload.delete(:params) if payload[:params].empty?
 

--- a/lib/rails_semantic_logger/rack/logger.rb
+++ b/lib/rails_semantic_logger/rack/logger.rb
@@ -54,6 +54,7 @@ module RailsSemanticLogger
           payload: {
             method: request.request_method,
             path:   request.filtered_path,
+            params: request.filtered_parameters,
             ip:     request.remote_ip
           }
         }


### PR DESCRIPTION
### Issue # (if available)

N/A

### Description of changes

When logging with sensitive information such as `password`, or whichever fields set in `config/initializers/filter_parameter_logging.rb`. Semantic logger still logs clear text. This change is trying to fix that.

I look into the `test` and I don't find a test for the changed file. Let me know I am more than happy to add tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
