### PR TITLE
Avoid warning when attempting to add a second console appender

### DIFF
--- a/lib/rails_semantic_logger/extensions/rails/server.rb
+++ b/lib/rails_semantic_logger/extensions/rails/server.rb
@@ -9,7 +9,7 @@ module Rails
     def log_to_stdout
       wrapped_app # touch the app so the logger is set up
 
-      SemanticLogger.add_appender(io: $stdout, formatter: :color)
+      SemanticLogger.add_appender(io: $stdout, formatter: :color) unless SemanticLogger.appenders.console_output?
     end
   end
 end


### PR DESCRIPTION

### Issue # (if available)

N/A.

### Description of changes

Starting a rails server that already features a console appender results in the following warning:

> 2022-02-02 18:52:19.697203 W [386462:52820] SemanticLogger::Appenders -- Ignoring attempt to add a second console appender: SemanticLogger::Appender::IO since it would result in duplicate console output.

This change fixes it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
