### PR TITLE
Only undefine Rails::Server#log_to_stdout if it's defined

### DIFF
--- a/lib/rails_semantic_logger/extensions/rails/server.rb
+++ b/lib/rails_semantic_logger/extensions/rails/server.rb
@@ -5,7 +5,7 @@ module Rails
   class Server
     private
     
-    undef_method :log_to_stdout if Rails::Server.method_defined?(:log_to_stdout)
+    undef_method :log_to_stdout if method_defined?(:log_to_stdout)
     def log_to_stdout
       wrapped_app # touch the app so the logger is set up
 

--- a/lib/rails_semantic_logger/extensions/rails/server.rb
+++ b/lib/rails_semantic_logger/extensions/rails/server.rb
@@ -5,7 +5,7 @@ module Rails
   class Server
     private
     
-    undef_method :log_to_stdout
+    undef_method :log_to_stdout if Rails::Server.method_defined?(:log_to_stdout)
     def log_to_stdout
       wrapped_app # touch the app so the logger is set up
 


### PR DESCRIPTION
I'm experiencing the following error when I run some Rake tasks that use
`rails_semantic_logger`:

```
NameError: undefined method `log_to_stdout' for class `Rails::Server'
```

I don't quite understand how `log_to_stdout` could be undefined, but
this fixes things for me, and seems to be a valid approach to the issue,
so I thought I'd try to land it upstream, so I can upgrade from v4.6.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.