### PR TITLE
Fix rendering of bind values for Rails 7

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -198,7 +198,8 @@ module RailsSemanticLogger
         alias bind_values bind_values_v5_0_3
         alias render_bind render_bind_v5_0_3
         alias type_casted_binds type_casted_binds_v5_0_3
-      elsif Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR > 0 # ~> 6.1.0
+      elsif (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR > 0) || # ~> 6.1.0
+            Rails::VERSION::MAJOR == 7
         alias bind_values bind_values_v6_1
         alias render_bind render_bind_v6_1
         alias type_casted_binds type_casted_binds_v5_1_5


### PR DESCRIPTION
### Issue #156

Fixes #156 

### Description of changes

This causes rendering of bind values to use the more modern style adopted in Rails 6.1. I've tested this on my own app and it works fine, but if there is a place to add a test case for this please let me know.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
