### PR TITLE
Add support for Sidekiq 7.x

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -111,7 +111,14 @@ module RailsSemanticLogger
       Resque.logger        = SemanticLogger[Resque] if defined?(Resque) && Resque.respond_to?(:logger=)
 
       # Replace the Sidekiq logger
-      Sidekiq.logger       = SemanticLogger[Sidekiq] if defined?(Sidekiq) && Sidekiq.respond_to?(:logger=)
+      if defined?(Sidekiq)
+        if Sidekiq.respond_to?(:logger=)
+          Sidekiq.logger = SemanticLogger[Sidekiq]
+        elsif Sidekiq::VERSION[..1] == '7.'
+          method = Sidekiq.server? ? :configure_server : :configure_client
+          Sidekiq.public_send(method) { |cfg| cfg.logger = SemanticLogger[Sidekiq] }
+        end
+      end
 
       # Replace the Sidetiq logger
       Sidetiq.logger       = SemanticLogger[Sidetiq] if defined?(Sidetiq) && Sidetiq.respond_to?(:logger=)


### PR DESCRIPTION
Sidekiq 7 API has changed and `Sidekiq.logger=` is not available anymore.
Changing Sidekiq config can be achieved through `configure_client` and `configure_server` methods.

### Description of changes
This PR checks whether Sidekiq 7 is available and injects the semantic logger accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
