### PR TITLE
remove action mailer require

### DIFF
--- a/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
@@ -1,5 +1,4 @@
 require "active_support/log_subscriber"
-require "action_mailer"
 
 module RailsSemanticLogger
   module ActionMailer


### PR DESCRIPTION
### Issue
When the host application don't use action mailer. it fail with the following error 

```
rails aborted!
LoadError: cannot load such file -- action_mailer/log_subscriber
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
