### PR TITLE
Add Ruby 3.2 to the CI matrix, fixes other CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - rails: 5.2
             ruby: 2.6
           - rails: 5.2
-            ruby: jruby
+            ruby: jruby-9.3
 
           - rails: "6.0"
             ruby: 2.6
@@ -35,19 +35,20 @@ jobs:
             ruby: jruby
 
           - rails: "7.0"
-            ruby: 3.1
-          - rails: "6.1"
-            ruby: jruby
-
+            ruby: "3.0"
           - rails: "7.0"
             ruby: 3.1
+          - rails: "7.0"
+            ruby: 3.2
+          - rails: "7.0"
+            ruby: jruby 
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
       DISPLAY: ":99.0"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Appraisals
+++ b/Appraisals
@@ -28,6 +28,6 @@ appraise "rails_7.0" do
   gem "thread_safe", "~> 0.3.6"
 
   gem "rails", "~> 7.0.0"
-  gem "activerecord-jdbcsqlite3-adapter", "~> 61.0", platform: :jruby
+  gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platform: :jruby
   gem "sqlite3", "~> 1.4.0", platform: :ruby
 end

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -14,7 +14,7 @@ gem "semantic_logger", github: "reidmorrison/semantic_logger"
 gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.4.0", platform: :ruby
 gem "thread_safe", "~> 0.3.6"
-gem "activerecord-jdbcsqlite3-adapter", "~> 61.0", platform: :jruby
+gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platform: :jruby
 
 group :development do
   gem "rubocop"


### PR DESCRIPTION
### Description of changes

Adds Ruby 3.2 to the CI matrix, and resolves a few other CI matrix issues.  These are:

1. Set the Rails 5.2 / jruby to use jruby-9.3 because jruby (9.4) is now a 3.1 compatible Ruby, and thus doesn't work with Rails 5.2
2. Removed two duplicate entries in the CI matrix
3. Added a Rails 7.0 / jruby entry.  This required minor modifications to the Appraisals / rails_7.0.gemfile to update the `activerecord-jdbcsqlite3-adapter` to `~> 7.0`

Also updated the version of the checkout action to `v3`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
