### PR TITLE
Fix if-else mismatched indentations warning

### DIFF
--- a/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
@@ -9,7 +9,7 @@ module RailsSemanticLogger
         message_id = event.payload[:message_id]
         duration = event.duration.round(1)
         if ex
-         log_with_formatter event: event, log_duration: true, level: :error do |fmt|
+          log_with_formatter event: event, log_duration: true, level: :error do |fmt|
             {
               message: "Error delivering mail #{message_id} (#{duration}ms)",
               exception: ex
@@ -17,7 +17,7 @@ module RailsSemanticLogger
           end
         else
           message = begin
-          if event.payload[:perform_deliveries]
+            if event.payload[:perform_deliveries]
               "Delivered mail #{message_id} (#{duration}ms)"
             else
               "Skipped delivery of mail #{message_id} as `perform_deliveries` is false"


### PR DESCRIPTION
### Issue # (if available)
Fixes the warning regarding a mismatched indentation at `lib/rails_semantic_logger/action_mailer/log_subscriber.rb`:

> warning: mismatched indentations at 'else' with 'if' at 20

You can run `RUBYOPT='-w' bundle exec rake test` to check the warning mentioned above.

### Description of changes

Only indentation :) We have a project that raises errors on warning so this is breaking our CI.
