### PR TITLE
Don't use 2.7+ syntax, which breaks compatibility with earlier Ruby versions

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -111,7 +111,7 @@ module RailsSemanticLogger
       if defined?(Sidekiq)
         if Sidekiq.respond_to?(:logger=)
           Sidekiq.logger = SemanticLogger[Sidekiq]
-        elsif Sidekiq::VERSION[..1] == '7.'
+        elsif Sidekiq::VERSION[0..1] == '7.'
           method = Sidekiq.server? ? :configure_server : :configure_client
           Sidekiq.public_send(method) { |cfg| cfg.logger = SemanticLogger[Sidekiq] }
         end


### PR DESCRIPTION
### Description of changes

Fixes the broken build/functionality for Ruby 2.5 and 2.6.  The use of 2.7+ syntax in `lib/rails_semantic_logger/engine.rb` breaks this library when used with those Rubies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
