### PR TITLE
Disable Bugsnag api key validation

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -127,7 +127,7 @@ module RailsSemanticLogger
       end
 
       # Replace the Bugsnag logger
-      Bugsnag.configure { |config| config.logger = SemanticLogger[Bugsnag] } if defined?(Bugsnag)
+      Bugsnag.configure(false) { |config| config.logger = SemanticLogger[Bugsnag] } if defined?(Bugsnag)
 
       # Set the IOStreams PGP logger
       IOStreams::Pgp.logger = SemanticLogger["IOStreams::Pgp"] if defined?(IOStreams)
@@ -138,7 +138,7 @@ module RailsSemanticLogger
       config = Rails.application.config
 
       # Replace the Bugsnag logger
-      Bugsnag.configure { |bugsnag_config| bugsnag_config.logger = SemanticLogger[Bugsnag] } if defined?(Bugsnag)
+      Bugsnag.configure(false) { |bugsnag_config| bugsnag_config.logger = SemanticLogger[Bugsnag] } if defined?(Bugsnag)
 
       # Rails Patches
       require("rails_semantic_logger/extensions/action_cable/tagged_logger_proxy") if defined?(::ActionCable)


### PR DESCRIPTION
### Description of changes

This will remove the warning "No valid API key has been set, notifications will not be sent" that will be logged in all environments as the Bugnsag api key hasn't been set yet as that happens later in the initialization process.

See https://github.com/bugsnag/bugsnag-ruby/blob/bdfbf3972f2137b3b9b95194a6bedf9c8edf6555/lib/bugsnag.rb#L61

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
