### PR TITLE
fix: handle nil logger in `ActiveJob::Logging`

### DIFF
--- a/lib/rails_semantic_logger/extensions/active_job/logging.rb
+++ b/lib/rails_semantic_logger/extensions/active_job/logging.rb
@@ -9,7 +9,11 @@ module ActiveJob
 
     undef_method :tag_logger
     def tag_logger(*tags, &block)
-      logger.tagged(*tags, &block)
+      if logger.respond_to?(:tagged)
+        logger.tagged(*tags, &block)
+      else
+        yield
+      end
     end
   end
 end


### PR DESCRIPTION
I was getting "undefined method 'tagged' for nil:NilClass (NoMethodError)" exceptions in `ActiveJob::Logging` as `logger` was `nil`. I wasn't sure whether I was not setting up logging correctly so I started out with a vanilla Rails project, created an active job class and raised an exception in it. `logger` wasn't set there either but `ActiveJob` [handles this case gracefully](https://github.com/rails/rails/blob/2f26d01a93c619c3327e6d310994f40b2538b6f6/activejob/lib/active_job/logging.rb#L22).

This pull request adds them same handling to the Rails semantic logger.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
