### PR TITLE
Fix enqueue messages for ActiveJob

### DIFF
--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -191,6 +191,76 @@ class ActiveJobTest < Minitest::Test
         end
       end
 
+      describe "#enqueue_at with exception object" do
+        let(:event_name) { "enqueue.active_job" }
+
+        let(:payload) do
+          {
+            adapter:          ActiveJob::QueueAdapters::InlineAdapter.new,
+            job:              job,
+            exception_object: ArgumentError.new("error")
+          }
+        end
+
+        it "logs message" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_at(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :error,
+            name:             "Rails",
+            message_includes: "Failed enqueuing ActiveJobTest::MyJob",
+            payload_includes: {
+              job_class:  "ActiveJobTest::MyJob",
+              queue:      "my_jobs",
+              event_name: "enqueue.active_job"
+            }
+          )
+          assert_includes messages[0].payload, :job_id
+
+          exception = messages[0].exception
+          assert exception.is_a?(ArgumentError)
+          assert_equal "error", exception.message
+        end
+      end
+
+      describe "#enqueue_at with throwing :abort" do
+        let(:event_name) { "enqueue.active_job" }
+
+        let(:payload) do
+          {
+            adapter: ActiveJob::QueueAdapters::InlineAdapter.new,
+            job:     job,
+            aborted: true
+          }
+        end
+
+        it "logs message" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_at(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :info,
+            name:             "Rails",
+            message_includes: "Failed enqueuing ActiveJobTest::MyJob",
+            payload_includes: {
+              job_class:  "ActiveJobTest::MyJob",
+              queue:      "my_jobs",
+              event_name: "enqueue.active_job"
+            }
+          )
+          assert_match /Failed enqueuing .*, a before_enqueue callback halted the enqueuing execution/, messages[0].message
+          assert_includes messages[0].payload, :job_id
+        end
+      end
+
+
       describe "ActiveJob::Logging::LogSubscriber::EventFormatter" do
         let(:formatter) do
           RailsSemanticLogger::ActiveJob::LogSubscriber::EventFormatter.new(event: event, log_duration: true)

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -121,6 +121,74 @@ class ActiveJobTest < Minitest::Test
         end
       end
 
+      describe "#enqueue with exception object" do
+        let(:event_name) { "enqueue.active_job" }
+
+        let(:payload) do
+          {
+            adapter:          ActiveJob::QueueAdapters::InlineAdapter.new,
+            job:              job,
+            exception_object: ArgumentError.new("error")
+          }
+        end
+
+        it "logs message" do
+          messages = semantic_logger_events do
+            subscriber.enqueue(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :error,
+            name:             "Rails",
+            message_includes: "Error enqueuing ActiveJobTest::MyJob",
+            payload_includes: {
+              job_class:  "ActiveJobTest::MyJob",
+              queue:      "my_jobs",
+              event_name: "enqueue.active_job"
+            }
+          )
+          assert_includes messages[0].payload, :job_id
+
+          exception = messages[0].exception
+          assert exception.is_a?(ArgumentError)
+          assert_equal "error", exception.message
+        end
+      end
+
+      describe "#enqueue with throwing :abort" do
+        let(:event_name) { "enqueue.active_job" }
+
+        let(:payload) do
+          {
+            adapter: ActiveJob::QueueAdapters::InlineAdapter.new,
+            job:     job,
+            aborted: true
+          }
+        end
+
+        it "logs message" do
+          messages = semantic_logger_events do
+            subscriber.enqueue(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :error,
+            name:             "Rails",
+            message_includes: "Failed enqueuing ActiveJobTest::MyJob, a before_enqueue callback halted the enqueuing execution.",
+            payload_includes: {
+              job_class:  "ActiveJobTest::MyJob",
+              queue:      "my_jobs",
+              event_name: "enqueue.active_job"
+            }
+          )
+          assert_includes messages[0].payload, :job_id
+        end
+      end
+
       describe "ActiveJob::Logging::LogSubscriber::EventFormatter" do
         let(:formatter) do
           RailsSemanticLogger::ActiveJob::LogSubscriber::EventFormatter.new(event: event, log_duration: true)

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -1,5 +1,4 @@
 require_relative "test_helper"
-require 'pry'
 
 class ActiveJobTest < Minitest::Test
   if defined?(ActiveJob)

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -1,4 +1,5 @@
 require_relative "test_helper"
+require 'pry'
 
 class ActiveJobTest < Minitest::Test
   if defined?(ActiveJob)
@@ -142,7 +143,7 @@ class ActiveJobTest < Minitest::Test
             messages[0],
             level:            :error,
             name:             "Rails",
-            message_includes: "Error enqueuing ActiveJobTest::MyJob",
+            message_includes: "Failed enqueuing ActiveJobTest::MyJob",
             payload_includes: {
               job_class:  "ActiveJobTest::MyJob",
               queue:      "my_jobs",
@@ -176,15 +177,16 @@ class ActiveJobTest < Minitest::Test
 
           assert_semantic_logger_event(
             messages[0],
-            level:            :error,
+            level:            :info,
             name:             "Rails",
-            message_includes: "Failed enqueuing ActiveJobTest::MyJob, a before_enqueue callback halted the enqueuing execution.",
+            message_includes: "Failed enqueuing ActiveJobTest::MyJob",
             payload_includes: {
               job_class:  "ActiveJobTest::MyJob",
               queue:      "my_jobs",
               event_name: "enqueue.active_job"
             }
           )
+          assert_match /Failed enqueuing .*, a before_enqueue callback halted the enqueuing execution/, messages[0].message
           assert_includes messages[0].payload, :job_id
         end
       end


### PR DESCRIPTION

# Description of issue:

We found an issue with the logs of ActiveJobs.
When a job has an error or throws an abort or  Rails Semantic Logger with still log "Enqueued Job..." despite the job not being enqueued.

```ruby
class NoOpJob < ApplicationJob
  before_enqueue -> { throw :abort }
end

NoOpJob.perform_later
# => false
```

```
# 2023-07-26 15:03:18.497244 I [15994:5240 subscriber.rb:149] Rails -- Enqueued NoOpJob (Job ID: 1f5c3c34-dfd0-4318-b83e-a31dc179812e) to GoodJob(default) -- { :event_name => "enqueue.active_job", :adapter => "GoodJob", :queue => "default", :job_class => "NoOpJob", :job_id => "1f5c3c34-dfd0-4318-b83e-a31dc179812e", :provider_job_id => nil, :arguments => "[\n\n]" }
```

Please find the corresponding log messages in the [Rails Repo](https://github.com/rails/rails/blob/4c9a990ffda8817e531b70c19c57ccc3078c0a22/activejob/lib/active_job/log_subscriber.rb#L6-L28) that differentiate between three events: errors, :abort and successful enqueing.

# Description of solution

We extended both methods `#enqueue` and `#enqueue_at` and also added test cases for those.

```ruby
class NoOpJob < ApplicationJob
  before_enqueue -> { throw :abort }
end

NoOpJob.perform_later
# => false
```
```
2023-07-26 15:04:37.069003 I [16286:5240 subscriber.rb:149] Rails -- Failed enqueuing NoOpJob (Job ID: 10dd3846-c887-4757-893f-88ae6b2d4ae5) to GoodJob(default), a before_enqueue callback halted the enqueuing execution. -- { :event_name => "enqueue.active_job", :adapter => "GoodJob", :queue => "default", :job_class => "NoOpJob", :job_id => "10dd3846-c887-4757-893f-88ae6b2d4ae5", :provider_job_id => nil, :arguments => "[\n\n]" }
```

```ruby
NoOpJob.set(wait: 5.minutes).perform_later
```

```
2023-07-26 15:06:13.494036 I [16286:5240 subscriber.rb:149] Rails -- Failed enqueuing NoOpJob (Job ID: 2f27e233-8be4-4e37-a151-84d308e05a1f) to GoodJob(default), a before_enqueue callback halted the enqueuing execution. -- { :event_name => "enqueue_at.active_job", :adapter => "GoodJob", :queue => "default", :job_class => "NoOpJob", :job_id => "2f27e233-8be4-4e37-a151-84d308e05a1f", :provider_job_id => nil, :arguments => "[\n\n]" }
```
