### PR TITLE
fix: remove undef :broadcast since ActiveSupport::Logger dropped it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,15 @@ jobs:
           - rails: "7.0"
             ruby: 3.2
           - rails: "7.0"
-            ruby: jruby 
+            ruby: jruby
+          - rails: "7.1"
+            ruby: "3.0"
+          - rails: "7.1"
+            ruby: 3.1
+          - rails: "7.1"
+            ruby: 3.2
+          - rails: "7.1"
+            ruby: jruby
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile

--- a/lib/rails_semantic_logger/extensions/active_support/logger.rb
+++ b/lib/rails_semantic_logger/extensions/active_support/logger.rb
@@ -7,7 +7,7 @@ module ActiveSupport
       undef :logger_outputs_to?
 
       # Prevent broadcasting since SemanticLogger already supports multiple loggers
-      if defined(:broadcast)
+      if method_defined?(:broadcast)
         undef :broadcast
         def broadcast(logger)
           Module.new

--- a/lib/rails_semantic_logger/extensions/active_support/logger.rb
+++ b/lib/rails_semantic_logger/extensions/active_support/logger.rb
@@ -4,7 +4,7 @@ module ActiveSupport
   # More hacks to try and stop Rails from being it's own worst enemy.
   class Logger
     class << self
-      undef :logger_outputs_to?, :broadcast
+      undef :logger_outputs_to?
     end
 
     # Prevent Console from trying to merge loggers

--- a/lib/rails_semantic_logger/extensions/active_support/logger.rb
+++ b/lib/rails_semantic_logger/extensions/active_support/logger.rb
@@ -20,10 +20,6 @@ module ActiveSupport
       true
     end
 
-    def self.broadcast(logger)
-      Module.new
-    end
-
     def self.new(*args, **kwargs)
       SemanticLogger[self]
     end

--- a/lib/rails_semantic_logger/extensions/active_support/logger.rb
+++ b/lib/rails_semantic_logger/extensions/active_support/logger.rb
@@ -5,6 +5,14 @@ module ActiveSupport
   class Logger
     class << self
       undef :logger_outputs_to?
+
+      # Prevent broadcasting since SemanticLogger already supports multiple loggers
+      if defined(:broadcast)
+        undef :broadcast
+        def broadcast(logger)
+          Module.new
+        end
+      end
     end
 
     # Prevent Console from trying to merge loggers
@@ -12,7 +20,6 @@ module ActiveSupport
       true
     end
 
-    # Prevent broadcasting since SemanticLogger already supports multiple loggers
     def self.broadcast(logger)
       Module.new
     end


### PR DESCRIPTION
### Issue # (if available)
Rails 7.1 dropped this method from ActiveSupport::Logger so trying to undefine it throws on boot

### Description of changes
Removed that one undef line


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
