### PR TITLE
Fix: `log_arguments` of Mailer does not work properly

### DIFF
--- a/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
@@ -92,7 +92,7 @@ module RailsSemanticLogger
         end
 
         def formatted_args
-          if defined?(mailer.contantize.log_arguments?) && !mailer.contantize.log_arguments?
+          if defined?(mailer.constantize.log_arguments?) && !mailer.constantize.log_arguments?
             ""
           else
             JSON.pretty_generate(event.payload[:args].map { |arg| format(arg) }) if event.payload[:args].present?


### PR DESCRIPTION
### Issue # (if available)

Even if `self.log_arguments: false` is set in Mailer, args is output as payload.

### Description of changes

Fixed typos in `formatted_args`, which caused always outputting args to logs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
