### PR TITLE
Fix: `log_arguments` of Mailer does not work properly

### DIFF
--- a/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
@@ -92,7 +92,7 @@ module RailsSemanticLogger
         end
 
         def formatted_args
-          if defined?(mailer.contantize.log_arguments?) && !mailer.contantize.log_arguments?
+          if defined?(mailer.constantize.log_arguments?) && !mailer.constantize.log_arguments?
             ""
           else
             JSON.pretty_generate(event.payload[:args].map { |arg| format(arg) }) if event.payload[:args].present?


### PR DESCRIPTION
### Issue # (if available)

The `log_arguments` setting in Mailer does not suppress argument logging when set to `false`. Arguments are still included in the payload.

### Description of changes

Corrected typos in the `formatted_args` method, which previously resulted in arguments being logged regardless of the `log_arguments` setting.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
