### PR TITLE
fix: rack server deprecated in rack 3

### DIFF
--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -59,4 +59,8 @@ end
 require("rails_semantic_logger/extensions/mongoid/config") if defined?(Mongoid)
 require("rails_semantic_logger/extensions/active_support/logger") if defined?(ActiveSupport::Logger)
 require("rails_semantic_logger/extensions/active_support/log_subscriber") if defined?(ActiveSupport::LogSubscriber)
-require("rails_semantic_logger/extensions/rack/server") if defined?(Rack::Server)
+if defined?(Rackup::Server)
+  require("rails_semantic_logger/extensions/rackup/server")
+elsif defined?(Rack::Server)
+  require("rails_semantic_logger/extensions/rack/server")
+end

--- a/lib/rails_semantic_logger/extensions/rackup/server.rb
+++ b/lib/rails_semantic_logger/extensions/rackup/server.rb
@@ -1,0 +1,12 @@
+module RailsSemanticLogger
+  module Rackup
+    module Server
+      def daemonize_app
+        super
+        SemanticLogger.reopen
+      end
+    end
+  end
+end
+
+Rackup::Server.prepend(RailsSemanticLogger::Rackup::Server)


### PR DESCRIPTION
### Issue # (if available)
Closes  #198

### Description of changes
Clones `Rack::Server` monkeypatch to `Rackup::Server`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
