### PR TITLE
Fix ActionDispatch::DebugExceptions extension deprecation on rails 7.1

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -6,9 +6,17 @@ module ActionDispatch
     private
 
     undef_method :log_error
-    def log_error(_request, wrapper)
-      ActiveSupport::Deprecation.silence do
-        ActionController::Base.logger.fatal(wrapper.exception)
+    if (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 7
+      def log_error(_request, wrapper)
+        Rails.application.deprecators.silence do
+          ActionController::Base.logger.fatal(wrapper.exception)
+        end
+      end
+    else
+      def log_error(_request, wrapper)
+        ActiveSupport::Deprecation.silence do
+          ActionController::Base.logger.fatal(wrapper.exception)
+        end
       end
     end
   end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -84,5 +84,24 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
         )
       end
     end
+
+    describe "#show" do
+      it "raises and logs exception" do
+        # we're testing ActionDispatch::DebugExceptions in fact
+        messages = semantic_logger_events do
+          old_show = Rails.application.env_config["action_dispatch.show_exceptions"]
+          begin
+            Rails.application.env_config["action_dispatch.show_exceptions"] = :all
+            get article_url(:show)
+          rescue ActiveRecord::RecordNotFound => e
+            # expected
+          ensure
+            Rails.application.env_config["action_dispatch.show_exceptions"] = old_show
+          end
+        end
+        assert_equal 4, messages.count, messages
+        assert_kind_of ActiveRecord::RecordNotFound, messages[3].exception
+      end
+    end
   end
 end

--- a/test/dummy/app/controllers/articles_controller.rb
+++ b/test/dummy/app/controllers/articles_controller.rb
@@ -5,4 +5,8 @@ class ArticlesController < ApplicationController
   def create
     render plain: params[:article].inspect
   end
+
+  def show
+    raise ActiveRecord::RecordNotFound
+  end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -6,6 +6,10 @@ Bundler.require
 
 module Dummy
   class Application < Rails::Application
+    if config.respond_to?(:load_defaults)
+      config.load_defaults "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"
+    end
+
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
     config.active_record.sqlite3.represent_boolean_as_integer = true if config.active_record.sqlite3

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -19,7 +19,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching          = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions            = false
+  config.action_dispatch.show_exceptions = Rails::VERSION::MAJOR >= 7 ? :none : false
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
### Issue # (if available)
This should fix https://github.com/reidmorrison/rails_semantic_logger/issues/203

### Description of changes
Added test for ActionDispatch::DebugExceptions and fixed couple of rails 7.1 deprecations in tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
