### PR TITLE
fix: Ensure the load order of the optional dependency of Rackup

### DIFF
--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -67,6 +67,12 @@ end
 require("rails_semantic_logger/extensions/mongoid/config") if defined?(Mongoid)
 require("rails_semantic_logger/extensions/active_support/logger") if defined?(ActiveSupport::Logger)
 require("rails_semantic_logger/extensions/active_support/log_subscriber") if defined?(ActiveSupport::LogSubscriber)
+
+begin
+  require 'rackup'
+rescue LoadError
+  # No need to do anything, will fall back to Rack
+end
 if defined?(Rackup::Server)
   require("rails_semantic_logger/extensions/rackup/server")
 elsif defined?(Rack::Server)


### PR DESCRIPTION
### Description of changes

rails_semantic logger has an optional dependency on Rackup.

Unfortunately, Bundler doesn't have a concept of an optional dependency, meaning that it doesn't enforce the loading of gems that aren't declared as a requirement in the gemspec. This means that rails_semantic_logger behavior actually depends on the ordering inside the Gemfile, and I don't think that was anyone's intention. 

This change force-preloads Rackup if it's available or works a usual if not. 

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
