### PR TITLE
Add controller name to controller logs

### DIFF
--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -5,7 +5,7 @@ module RailsSemanticLogger
 
       # Log as debug to hide Processing messages in production
       def start_processing(event)
-        controller_logger(event).debug { "Processing ##{event.payload[:action]}" }
+        controller_logger(event).debug { "Processing #{event.payload[:controller]}##{event.payload[:action]}" }
       end
 
       def process_action(event)
@@ -59,7 +59,7 @@ module RailsSemanticLogger
           payload.delete(:response)
 
           {
-            message:  "Completed ##{payload[:action]}",
+            message:  "Completed #{payload[:controller]}##{payload[:action]}",
             duration: event.duration,
             payload:  payload
           }

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -39,7 +39,7 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
 
         assert_semantic_logger_event(
           messages[1],
-          message: "Processing #create",
+          message: "Processing ArticlesController#create",
           name:    "ArticlesController",
           level:   :debug
         )
@@ -63,7 +63,7 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
 
         assert_semantic_logger_event(
           messages[4],
-          message:          "Completed #create",
+          message:          "Completed ArticlesController#create",
           name:             "ArticlesController",
           level:            :info,
           payload_includes: {

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -31,7 +31,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
           messages[1],
           level:   :debug,
           name:    "Rails",
-          message: "Processing #show",
+          message: "Processing DashboardController#show",
           payload: nil
         )
 
@@ -39,7 +39,7 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
           messages[2],
           level:            :info,
           name:             "Rails",
-          message:          "Completed #show",
+          message:          "Completed DashboardController#show",
           payload_includes: {
             controller:     "DashboardController",
             action:         "show",


### PR DESCRIPTION
### Issue # (if available)
Related to #149 (but does NOT fix the issue - it does not make it possible to modify the message, simply make it slightly more descriptive in rails controller logs).

For context, here's how SemanticLogger logs are listed in Datadog by default:
![Screenshot 2024-04-22 at 11 10 45](https://github.com/reidmorrison/rails_semantic_logger/assets/9031589/27a11ef8-f3e4-470a-abc3-ab2c3b293327)
(sure: I can also filter by log name or even add a column displaying the log name - but as it is the message isn't very helpful.)

### Description of changes
Add controller name to Rails controller logs, so instead of 
`Completed #show`

We might have instead:
`Completed UsersController#show`