### PR TITLE
fix: avoid false positives during Resque detection

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -239,7 +239,7 @@ module RailsSemanticLogger
       end
 
       # Re-open appenders after Resque has forked a worker
-      Resque.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Resque)
+      Resque.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Resque.after_fork)
 
       # Re-open appenders after Spring has forked a process
       Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)


### PR DESCRIPTION
### Issue

When combining Semantic Logger with other gems that use the `Resque` namespace and the host app does not use the [`resque` gem](https://rubygems.org/gems/resque), Semantic logger causes a failure during the boot up sequence.

### Description of changes

The change makes Resque detection more robust in order to avoid a false positive detection and the subsequent failure in the host's app boot up sequence.

This also aligns the detection with other instances of detecting Resque:

https://github.com/reidmorrison/rails_semantic_logger/blob/eadda203513334f850bc0bc809c295d26642649c/lib/rails_semantic_logger/engine.rb#L108

and detecting other forking:

https://github.com/reidmorrison/rails_semantic_logger/blob/eadda203513334f850bc0bc809c295d26642649c/lib/rails_semantic_logger/engine.rb#L245

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
