### PR TITLE
Update deprecated ActiveSupport::Deprecation.silence class method to instance method

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -7,7 +7,7 @@ module ActionDispatch
 
     undef_method :log_error
     def log_error(_request, wrapper)
-      ActiveSupport::Deprecation.silence do
+      ActiveSupport::Deprecation.new.silence do
         ActionController::Base.logger.fatal(wrapper.exception)
       end
     end


### PR DESCRIPTION
### Issue # (if available)


### Description of changes
The `ActiveSupport::Deprecation.silence` class method has been deprecated for an instance method, or `ActiveSupport::Deprecation.new.silence`. This PR is to reflect this update in the codebase. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
