### PR TITLE
Replace Awesome Print to Amazing Print

### DIFF
--- a/lib/rails_semantic_logger/options.rb
+++ b/lib/rails_semantic_logger/options.rb
@@ -22,14 +22,14 @@ module RailsSemanticLogger
   #
   #     config.rails_semantic_logger.rendered = false
   #
-  # * Override the Awesome Print options for logging Hash data as text:
+  # * Override the Amazing Print options for logging Hash data as text:
   #
-  #     Any valid AwesomePrint option for rendering data.
+  #     Any valid Amazing Print option for rendering data.
   #     The defaults can changed be creating a `~/.aprc` file.
-  #     See: https://github.com/michaeldv/awesome_print
+  #     See: https://github.com/amazing-print/amazing_print
   #
   #     Note: The option :multiline is set to false if not supplied.
-  #     Note: Has no effect if Awesome Print is not installed.
+  #     Note: Has no effect if Amazing Print is not installed.
   #
   #        config.rails_semantic_logger.ap_options = {multiline: false}
   #


### PR DESCRIPTION
### Issue # (if available)

None

### Description of changes

Semantic Logger suggests to use Amazing Print since https://github.com/reidmorrison/semantic_logger/commit/22ca2027910ba80218893fd2596df43f67566497
This updates the doc to suggest `Awesome Print` following the Semantic Logger changes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
