### PR TITLE
Fix Rails supported version

### DIFF
--- a/rails_semantic_logger.gemspec
+++ b/rails_semantic_logger.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.license               = "Apache-2.0"
   s.required_ruby_version = ">= 2.5"
   s.add_dependency "rack"
-  s.add_dependency "railties", ">= 5.1"
+  s.add_dependency "railties", ">= 6.0"
   s.add_dependency "semantic_logger", "~> 4.16"
   s.metadata = {
     "bug_tracker_uri"       => "https://github.com/reidmorrison/rails_semantic_logger/issues",


### PR DESCRIPTION

### Description of changes

It seems that CI is only run against Rails >= 6.0 since https://github.com/reidmorrison/rails_semantic_logger/commit/ee5e80d95e99cf45a267a3882f5a734e8326f494
This changes the supported version to match with CI matrix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
