### PR TITLE
Include async:true on async queries

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -33,6 +33,7 @@ module RailsSemanticLogger
         log_payload[:binds] = bind_values(payload) unless (payload[:binds] || []).empty?
         log_payload[:allocations] = event.allocations if event.respond_to?(:allocations)
         log_payload[:cached] = event.payload[:cached]
+        log_payload[:async] = true if event.payload[:async]
 
         log = {
           message:  name,

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -11,6 +11,7 @@ module Dummy
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
     config.active_record.sqlite3.represent_boolean_as_integer = true if config.active_record.sqlite3
+    config.active_record.async_query_executor = :global_thread_pool
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
### Description of changes

WDYT to something like this? It includes `async: true` in the payload of ActiveRecord logs if the query is async.

For synchronous queries, I've left the payload as-is (rather than adding `async: false`), on the assumption that 99% of your queries are probably synchronous, but I don't have a strong feeling either way on that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
