### PR TITLE
Unsubscribe all listeners in Rails >= 7.1

### DIFF
--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -49,7 +49,7 @@ module RailsSemanticLogger
 
   def self.unattach(subscriber)
     subscriber_patterns(subscriber).each do |pattern|
-      ActiveSupport::Notifications.notifier.listeners_for(pattern).each do |sub|
+      listeners_for(ActiveSupport::Notifications.notifier, pattern).each do |sub|
         next unless sub.instance_variable_get(:@delegate) == subscriber
 
         ActiveSupport::Notifications.unsubscribe(sub)
@@ -67,7 +67,15 @@ module RailsSemanticLogger
     end
   end
 
-  private_class_method :subscriber_patterns, :unattach
+  def self.listeners_for(notifier, pattern)
+    if notifier.respond_to?(:all_listeners_for) # Rails >= 7.1
+      notifier.all_listeners_for(pattern)
+    else
+      notifier.listeners_for(pattern)
+    end
+  end
+
+  private_class_method :listeners_for, :subscriber_patterns, :unattach
 end
 
 require("rails_semantic_logger/extensions/mongoid/config") if defined?(Mongoid)


### PR DESCRIPTION
### Background

In the app I'm working on, we've (mostly) silenced logs in CI via

```rb
# config/environments/test.rb
if ENV['CI']
  config.log_level = :fatal
end
```

There are some tests that explicitly test logging, though, so for the duration of those test we drop the log level down back down to `:info`.

While upgrading this app from Rails 7 to Rails 7.1, we saw some odd failures in these tests — both the Rails-default logs and the `rails_semantic_logger` logs were being printed. It seems to be due to the changes made in https://github.com/rails/rails/pull/45796 to the `listeners_for` method, which `rails_semantic_logger` uses to unsubscribe existing log subscribers. In short:

- With `log_level = :fatal`, when `rails_semantic_logger` is first loaded, `listeners_for` doesn't return the Rails-default log subscribers, since they're currently silenced
- When we drop the log level back down, those listeners are now un-silenced, and output their logs

### Description of changes

This PR uses `all_listeners_for`, where available, to ensure that currently-silenced subscribers also get unsubscribed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
