### PR TITLE
Auto-detect SolidQueue

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -267,6 +267,7 @@ module RailsSemanticLogger
       Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)
 
       # Re-open appenders after SolidQueue worker/dispatcher/scheduler has finished booting
+      SolidQueue.on_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_start)
       SolidQueue.on_worker_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_worker_start)
       SolidQueue.on_dispatcher_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_dispatcher_start)
       SolidQueue.on_scheduler_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_scheduler_start)

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -266,8 +266,10 @@ module RailsSemanticLogger
       # Re-open appenders after Spring has forked a process
       Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)
 
-      # Re-open appenders after SolidQueue has forked a worker
+      # Re-open appenders after SolidQueue worker/dispatcher/scheduler has finished booting
       SolidQueue.on_worker_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_worker_start)
+      SolidQueue.on_dispatcher_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_dispatcher_start)
+      SolidQueue.on_scheduler_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_scheduler_start)
 
       console do |_app|
         # Don't use a background thread for logging

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -266,6 +266,9 @@ module RailsSemanticLogger
       # Re-open appenders after Spring has forked a process
       Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)
 
+      # Re-open appenders after SolidQueue has forked a worker
+      SolidQueue.on_worker_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_worker_start)
+
       console do |_app|
         # Don't use a background thread for logging
         SemanticLogger.sync!


### PR DESCRIPTION
### Issue 

https://github.com/reidmorrison/rails_semantic_logger/issues/237

### Description of changes

Adds SolidQueue as an auto-detected framework. 

Reading through the Solid Queue docs it says:

> Solid Queue's supervisor will fork a separate process for each supervised worker/dispatcher/scheduler.

~ https://github.com/rails/solid_queue?tab=readme-ov-file#workers-dispatchers-and-scheduler

It also offers four hooks

```ruby
SolidQueue.on_start
SolidQueue.on_stop

SolidQueue.on_worker_start
SolidQueue.on_worker_stop
```

~ https://github.com/rails/solid_queue?tab=readme-ov-file#lifecycle-hooks

So I found that by adding

```rb
# config/initializers/solid_queue.rb

SolidQueue.on_worker_start do
  # Re-open appenders after forking the process
  SemanticLogger.reopen
end
```

The logs started to appear in STDOUT. 

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
