### PR TITLE
Fix checking of Rails version on ActiveRecord log subscriber

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -196,8 +196,8 @@ module RailsSemanticLogger
         alias bind_values bind_values_v5_0_3
         alias render_bind render_bind_v5_0_3
         alias type_casted_binds type_casted_binds_v5_0_3
-      elsif (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR > 0) || # ~> 6.1.0
-            Rails::VERSION::MAJOR == 7
+      elsif (Rails::VERSION::MAJOR == 6 && Rails::VERSION::MINOR > 0) ||
+            Rails::VERSION::MAJOR >= 7 # ~> 6.1.0 && >= 7.x.x
         alias bind_values bind_values_v6_1
         alias render_bind render_bind_v6_1
         alias type_casted_binds type_casted_binds_v5_1_5


### PR DESCRIPTION
### Issue 
https://github.com/reidmorrison/rails_semantic_logger/issues/249

### Description of changes
Don't check only for Rails 7, check for all version after also (Rails 8 and the future ones).

I see that on other parts of code you have conditions where you check if Rails version is bigger than 7 so I think this would be good to have for compatibility with new Rails versions. Of course, if there would be some needed changes in some Rails version in future, we would add new condition, but in case there is no need for that like now on Rails 8, we wouldn't have errors.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
