### PR TITLE
Fix sidekiq logger reference in ERROR_HANDLER

### DIFF
--- a/lib/rails_semantic_logger/sidekiq/defaults.rb
+++ b/lib/rails_semantic_logger/sidekiq/defaults.rb
@@ -9,7 +9,7 @@ module RailsSemanticLogger
             unless ctx.empty?
               job_hash = ctx[:job] || {}
               klass    = job_hash["display_class"] || job_hash["wrapped"] || job_hash["class"]
-              logger   = klass ? SemanticLogger[klass] : Sidekiq.logger
+              logger   = klass ? SemanticLogger[klass] : ::Sidekiq.logger
               ctx[:context] ? logger.warn(ctx[:context], ctx) : logger.warn(ctx)
             end
           end
@@ -18,7 +18,7 @@ module RailsSemanticLogger
             unless ctx.empty?
               job_hash = ctx[:job] || {}
               klass    = job_hash["display_class"] || job_hash["wrapped"] || job_hash["class"]
-              logger   = klass ? SemanticLogger[klass] : Sidekiq.logger
+              logger   = klass ? SemanticLogger[klass] : ::Sidekiq.logger
               ctx[:context] ? logger.warn(ctx[:context], ctx) : logger.warn(ctx)
             end
           end


### PR DESCRIPTION
This pull request updates the `RailsSemanticLogger` integration with Sidekiq by ensuring the logger references are fully qualified to avoid potential namespace conflicts.

Namespace qualification updates:

* [`lib/rails_semantic_logger/sidekiq/defaults.rb`](diffhunk://#diff-dbf2af746a7d1efaf7a1aa9f7a17ce46bc83f632da75276422d7cfba4809cb0fL12-R12): Updated `Sidekiq.logger` to `::Sidekiq.logger` in two places within the `Defaults` module to ensure proper namespace resolution. [[1]](diffhunk://#diff-dbf2af746a7d1efaf7a1aa9f7a17ce46bc83f632da75276422d7cfba4809cb0fL12-R12) [[2]](diffhunk://#diff-dbf2af746a7d1efaf7a1aa9f7a17ce46bc83f632da75276422d7cfba4809cb0fL21-R21)