### PR TITLE
Respect action_dispatch.log_rescued_responses

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
+++ b/lib/rails_semantic_logger/extensions/action_dispatch/debug_exceptions.rb
@@ -7,9 +7,11 @@ module ActionDispatch
 
     undef_method :log_error
     if (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR >= 1) || Rails::VERSION::MAJOR > 7
-      def log_error(_request, wrapper)
+      def log_error(request, wrapper)
         Rails.application.deprecators.silence do
-          level = wrapper.respond_to?(:rescue_response?) && wrapper.rescue_response? ? :debug : :fatal
+          return if !log_rescued_responses?(request) && wrapper.rescue_response?
+
+          level = request.get_header("action_dispatch.debug_exception_log_level")
           ActionController::Base.logger.log(level, wrapper.exception)
         end
       end

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -141,6 +141,27 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
         assert_equal 4, messages.count, messages
         assert_kind_of ActiveRecord::RecordNotFound, messages[3].exception
       end
+
+      it "raises and does not log exception when action_dispatch.log_rescued_responses is false" do
+        skip "Not applicable to older rails" if Rails.version.to_f < 7.1
+        # we're testing ActionDispatch::DebugExceptions here too
+        messages = semantic_logger_events do
+          old_show = Rails.application.env_config["action_dispatch.show_exceptions"]
+          old_log_rescued_responses = Rails.application.env_config["action_dispatch.log_rescued_responses"]
+
+          begin
+            Rails.application.env_config["action_dispatch.show_exceptions"] = :all
+            Rails.application.env_config["action_dispatch.log_rescued_responses"] = false
+            get article_url(:show)
+          rescue ActiveRecord::RecordNotFound => e
+            # expected
+          ensure
+            Rails.application.env_config["action_dispatch.show_exceptions"] = old_show
+            Rails.application.env_config["action_dispatch.log_rescued_responses"] = old_log_rescued_responses
+          end
+        end
+        assert_equal 3, messages.count, messages
+      end
     end
   end
 end


### PR DESCRIPTION
This is a new configuration option in Rails 7 which defaults to true. When an app sets this to false, this method does not log anything at all for rescued responses.

Because rails_semantic_logger monkey patches
ActionDispatch::DebugExceptions and overrides this method, this configuration option does not have any effect. Let's correct that.

More context on this configuration option:

- PR which introduced it https://github.com/rails/rails/pull/42592
- Evidence that this implementation should work fine in Rails 7.1+ https://github.com/rails/rails/blob/v7.1.0/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L137

I also noticed that rails_semantic_logger is not respecting the action_dispatch.debug_exception_log_level configuration, and it makes its own decisions about what is an appropriate level. I updated this to also follow that configuration.

This is also how it works in Rails 7.1+:
https://github.com/rails/rails/blob/v7.1.0/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L154

### Issue # (if available)


### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
