### PR TITLE
avoid crashing in no assets (api only) mode

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -204,7 +204,7 @@ module RailsSemanticLogger
         RailsSemanticLogger::Rack::Logger.started_request_log_level = :info if config.rails_semantic_logger.started
 
         # Silence asset logging by applying a filter to the Rails logger itself, not any of the appenders.
-        if config.rails_semantic_logger.quiet_assets && config.assets.prefix
+        if config.rails_semantic_logger.quiet_assets && config.respond_to?(:assets) && config.assets.prefix
           assets_root                                     = config.relative_url_root.to_s + config.assets.prefix
           assets_regex                                    = %r(\A/{0,2}#{assets_root})
           RailsSemanticLogger::Rack::Logger.logger.filter = ->(log) { log.payload[:path] !~ assets_regex if log.payload }


### PR DESCRIPTION
### Description of changes

Rails apps can run in API only mode, which means they do not have an asset pipeline. If one tries to call config.assets for an app like that one gets the following crash:

```
NoMethodError: undefined method 'assets' for an instance of Rails::Application::Configuration (NoMethodError)
Did you mean?  asset_host
my-app/config/environment.rb:7:in '<main>'
/bundle:25:in 'Kernel#load'
bundle:25:in '<main>'
```

The code a few lines above (95-100) ([ref](https://github.com/0robustus1/rails_semantic_logger/blob/master/lib/rails_semantic_logger/engine.rb#L95-L100)) is already written defensively. This does the same for this invocation of config.assets.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
