### PR TITLE
ActiveRecord::RuntimeRegistry.sql_runtime private API moved

### DIFF
--- a/lib/rails_semantic_logger/active_record/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_record/log_subscriber.rb
@@ -8,11 +8,15 @@ module RailsSemanticLogger
       end
 
       def self.runtime=(value)
-        ::ActiveRecord::RuntimeRegistry.sql_runtime = value
+        ::ActiveRecord::RuntimeRegistry.respond_to?(:stats) ?
+          ::ActiveRecord::RuntimeRegistry.stats.sql_runtime = value :
+          ::ActiveRecord::RuntimeRegistry.sql_runtime = value
       end
 
       def self.runtime
-        ::ActiveRecord::RuntimeRegistry.sql_runtime ||= 0
+        ::ActiveRecord::RuntimeRegistry.respond_to?(:stats) ?
+          ::ActiveRecord::RuntimeRegistry.stats.sql_runtime ||= 0 :
+          ::ActiveRecord::RuntimeRegistry.sql_runtime ||= 0
       end
 
       def self.reset_runtime


### PR DESCRIPTION
See: rails/rails@7d12071

This change will land in Rails 8.1.