### PR TITLE
Configuration to toggle off "perform" Sidekiq messages

### DIFF
--- a/lib/rails_semantic_logger/extensions/sidekiq/sidekiq.rb
+++ b/lib/rails_semantic_logger/extensions/sidekiq/sidekiq.rb
@@ -44,18 +44,27 @@ module Sidekiq
           # rubocop:disable Style/ExplicitBlockArgument
           def call(worker, item, queue)
             SemanticLogger.tagged(queue: queue) do
-              worker.logger.info(
-                "Start #perform",
-                metric:        "sidekiq.queue.latency",
-                metric_amount: job_latency_ms(item)
-              )
-              worker.logger.measure_info(
-                "Completed #perform",
-                on_exception_level: :error,
-                log_exception:      :full,
-                metric:             "sidekiq.job.perform"
-              ) { yield }
+              if perform_messages_enabled?
+                worker.logger.info(
+                  "Start #perform",
+                  metric:        "sidekiq.queue.latency",
+                  metric_amount: job_latency_ms(item)
+                )
+
+                worker.logger.measure_info(
+                  "Completed #perform",
+                  on_exception_level: :error,
+                  log_exception:      :full,
+                  metric:             "sidekiq.job.perform"
+                ) { yield }
+              else
+                yield
+              end
             end
+          end
+
+          def perform_messages_enabled?
+            RailsSemanticLogger::Sidekiq::JobLogger.perform_messages != false
           end
 
           def job_latency_ms(job)

--- a/lib/rails_semantic_logger/sidekiq/job_logger.rb
+++ b/lib/rails_semantic_logger/sidekiq/job_logger.rb
@@ -1,6 +1,14 @@
 module RailsSemanticLogger
   module Sidekiq
     class JobLogger
+      class << self
+        attr_writer :perform_messages
+
+        def perform_messages
+          instance_variable_defined?(:@perform_messages) ? @perform_messages : true
+        end
+      end
+
       # Sidekiq 6.5 does not take any arguments, whereas v7 is given a logger
       def initialize(*_args)
       end
@@ -10,21 +18,27 @@ module RailsSemanticLogger
         logger = klass ? SemanticLogger[klass] : Sidekiq.logger
 
         SemanticLogger.tagged(queue: queue) do
+          if perform_messages_enabled?
           # Latency is the time between when the job was enqueued and when it started executing.
-          logger.info(
-            "Start #perform",
-            metric:        "sidekiq.queue.latency",
-            metric_amount: job_latency_ms(item)
-          )
+            logger.info(
+              "Start #perform",
+              metric:        "sidekiq.queue.latency",
+              metric_amount: job_latency_ms(item)
+            )
+          end
 
           # Measure the duration of running the job
-          logger.measure_info(
-            "Completed #perform",
-            on_exception_level: :error,
-            log_exception:      :full,
-            metric:             "sidekiq.job.perform",
-            &block
-          )
+          if perform_messages_enabled?
+            logger.measure_info(
+              "Completed #perform",
+              on_exception_level: :error,
+              log_exception:      :full,
+              metric:             "sidekiq.job.perform",
+              &block
+            )
+          else
+            yield if block_given?
+          end
         end
       end
 
@@ -40,6 +54,10 @@ module RailsSemanticLogger
       end
 
       private
+
+      def perform_messages_enabled?
+        self.class.perform_messages != false
+      end
 
       def job_hash_context(job_hash)
         h         = {jid: job_hash["jid"]}


### PR DESCRIPTION
### Description of changes

v4.15 (or v4.16) introduced `#perform` messages in the Sidekiq job logger:
* "Start #perform"
* "Completed #perform"

We run hundreds of thousands of Sidekiq jobs every hour, and this decision had the unintended consequence of costing us a non-trivial amount of money, not to mention logging noise that interfered with issue investigation.

This commit introduces a configuration parameter `RailsSemanticLogger::Sidekiq::JobLogger.perform_messages` to opt out of these messages included by default.

Notes:
While it would have been preferable for the configuration parameter to not reference the internal module structure/API of `rails_semantic_logger`, the alternative (without impacting `SemanticLogger`) would have been to add this Sidekiq-specific setting into the global `options` set, which seemed less appropriate. There is already [referred precedence](https://github.com/reidmorrison/rails_semantic_logger/pull/235#issuecomment-2332906089) for such configuration settings that reference internal modules of `rails_semantic_logger`, so this patch went in that direction.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
