### PR TITLE
Add toggle to prevent Sidekiq logger replacement

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -108,7 +108,7 @@ module RailsSemanticLogger
       Resque.logger        = SemanticLogger[Resque] if defined?(Resque) && Resque.respond_to?(:logger=)
 
       # Replace the Sidekiq logger
-      if defined?(::Sidekiq)
+      if config.rails_semantic_logger.replace_sidekiq_logger && defined?(::Sidekiq)
         ::Sidekiq.configure_client do |config|
           config.logger = ::SemanticLogger[::Sidekiq]
         end
@@ -245,7 +245,9 @@ module RailsSemanticLogger
           )
         end
 
-        require("rails_semantic_logger/extensions/sidekiq/sidekiq") if defined?(::Sidekiq)
+        if config.rails_semantic_logger.replace_sidekiq_logger && defined?(::Sidekiq)
+          require("rails_semantic_logger/extensions/sidekiq/sidekiq")
+        end
       end
 
       #

--- a/lib/rails_semantic_logger/options.rb
+++ b/lib/rails_semantic_logger/options.rb
@@ -108,24 +108,30 @@ module RailsSemanticLogger
   #     config.rails_semantic_logger.action_message_format = -> (message, payload) do
   #       "#{message} - #{payload[:controller]}##{payload[:action]}"
   #     end
+  #
+  # * Do not replace the Sidekiq logger with a Semantic Logger logger.
+  #
+  #     config.rails_semantic_logger.replace_sidekiq_logger = false
   class Options
     attr_accessor :semantic, :started, :processing, :rendered, :ap_options, :add_file_appender,
-                  :quiet_assets, :format, :named_tags, :filter, :console_logger, :action_message_format
+                  :quiet_assets, :format, :named_tags, :filter, :console_logger, :action_message_format,
+                  :replace_sidekiq_logger
 
     # Setup default values
     def initialize
-      @semantic              = true
-      @started               = false
-      @processing            = false
-      @rendered              = false
-      @ap_options            = {multiline: false}
-      @add_file_appender     = true
-      @quiet_assets          = false
-      @format                = :default
-      @named_tags            = nil
-      @filter                = nil
-      @console_logger        = true
-      @action_message_format = nil
+      @semantic               = true
+      @started                = false
+      @processing             = false
+      @rendered               = false
+      @ap_options             = {multiline: false}
+      @add_file_appender      = true
+      @quiet_assets           = false
+      @format                 = :default
+      @named_tags             = nil
+      @filter                 = nil
+      @console_logger         = true
+      @action_message_format  = nil
+      @replace_sidekiq_logger = true
     end
   end
 end


### PR DESCRIPTION
In some circumstances, you don't want Semantic logger to replace the Sidekiq logger. This simple toggle allows you to control this behaviour.

### Issue # (if available)

None.

### Description of changes

Adds a simple toggle that allows turning off the automatic Sidekiq logger override.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
