### PR TITLE
Fix Sidekiq 8 compatibility in JobLogger.job_latency_ms

### DIFF
--- a/lib/rails_semantic_logger/sidekiq/job_logger.rb
+++ b/lib/rails_semantic_logger/sidekiq/job_logger.rb
@@ -70,7 +70,15 @@ module RailsSemanticLogger
       def job_latency_ms(job)
         return unless job && job["enqueued_at"]
 
-        (Time.now.to_f - job["enqueued_at"].to_f) * 1000
+        enqueued_at = job["enqueued_at"]
+        if enqueued_at.is_a?(Float)
+          # Sidekiq <= 7: seconds since epoch
+          (Time.now.to_f - enqueued_at) * 1000
+        else
+          # Sidekiq 8+: milliseconds since epoch
+          now = Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
+          now - enqueued_at
+        end
       end
     end
   end

--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -17,7 +17,7 @@ class SidekiqTest < Minitest::Test
 
     describe "#perform" do
       let(:config) { Sidekiq.default_configuration }
-      let(:msg) { Sidekiq.dump_json({"class" => job.to_s, "args" => args, "enqueued_at" => 1.minute.ago}) }
+      let(:msg) { Sidekiq.dump_json({"class" => job.to_s, "args" => args, "enqueued_at" => (Time.now - 60).to_f}) }
       let(:uow) { Sidekiq::BasicFetch::UnitOfWork.new("queue:default", msg) }
       if Sidekiq::VERSION.to_i == 6 && Sidekiq::VERSION.to_f < 6.5
         let(:processor) do
@@ -62,6 +62,40 @@ class SidekiqTest < Minitest::Test
           named_tags: {jid: nil, queue: "default"}
         )
         assert messages[0].metric_amount.is_a?(Float)
+
+        assert_semantic_logger_event(
+          messages[1],
+          level:      :info,
+          name:       "SimpleJob",
+          message:    "Completed #perform",
+          metric:     "sidekiq.job.perform",
+          named_tags: {jid: nil, queue: "default"}
+        )
+        assert messages[1].duration.is_a?(Float)
+      end
+
+      it "a simple job with Sidekiq 8+ timestamp (milliseconds)" do
+        # Sidekiq 8+ stores enqueued_at as milliseconds since epoch (Integer)
+        enqueued_at_ms = (Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond) - 60000).to_i
+        msg_sidekiq8 = Sidekiq.dump_json({"class" => job.to_s, "args" => args, "enqueued_at" => enqueued_at_ms})
+        uow_sidekiq8 = Sidekiq::BasicFetch::UnitOfWork.new("queue:default", msg_sidekiq8)
+
+        messages = semantic_logger_events do
+          processor.send(:process, uow_sidekiq8)
+        end
+
+        assert_equal 2, messages.count, -> { messages.collect(&:to_h).ai }
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:      :info,
+          name:       "SimpleJob",
+          message:    "Start #perform",
+          metric:     "sidekiq.queue.latency",
+          named_tags: {jid: nil, queue: "default"}
+        )
+        # Sidekiq 8+ returns Integer latency, whereas earlier versions return Float
+        assert messages[0].metric_amount.is_a?(Numeric)
 
         assert_semantic_logger_event(
           messages[1],


### PR DESCRIPTION
### Issue #287

### Description of changes

Starting with Sidekiq 8, enqueued_at is stored as milliseconds since epoch (Integer) instead of seconds since epoch (Float). The job_latency_ms method in JobLogger was not handling this change, causing incorrect negative metric values to be logged.

This fix applies the same logic as was already applied to the middleware in commit e71c0e4, checking the type of enqueued_at and handling both Sidekiq <= 7 (Float/seconds) and Sidekiq 8+ (Integer/milliseconds) correctly.

Test for sidekiq 8 added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
