### PR TITLE
Handle ActionCable loggers without #tags

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
+++ b/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
@@ -4,7 +4,7 @@ module ActionCable
   module Connection
     class TaggedLoggerProxy
       def tag(logger, &block)
-        current_tags = tags - logger.tags
+        current_tags = tags - (logger.respond_to?(:tags) ? Array(logger.tags) : [])
         logger.tagged(*current_tags, &block)
       end
     end

--- a/test/extensions/action_cable/tagged_logger_proxy_test.rb
+++ b/test/extensions/action_cable/tagged_logger_proxy_test.rb
@@ -1,0 +1,44 @@
+require_relative "../../test_helper"
+
+class TaggedLoggerProxyTest < Minitest::Test
+  class LoggerWithoutTags
+    attr_reader :received_tags
+
+    def tagged(*tags)
+      @received_tags = tags
+      yield
+    end
+  end
+
+  class LoggerWithTags < LoggerWithoutTags
+    attr_reader :tags
+
+    def initialize(tags)
+      @tags = tags
+    end
+  end
+
+  def test_tag_does_not_require_logger_tags
+    logger = LoggerWithoutTags.new
+
+    tagged_logger_proxy.send(:tag, logger) { :ok }
+
+    assert_equal [ :request_id, :user_id ], logger.received_tags
+  end
+
+  def test_tag_removes_duplicate_tags_when_logger_exposes_tags
+    logger = LoggerWithTags.new([ :request_id ])
+
+    tagged_logger_proxy.send(:tag, logger) { :ok }
+
+    assert_equal [ :user_id ], logger.received_tags
+  end
+
+  private
+
+  def tagged_logger_proxy
+    proxy = ActionCable::Connection::TaggedLoggerProxy.allocate
+    proxy.singleton_class.define_method(:tags) { [ :request_id, :user_id ] }
+    proxy
+  end
+end


### PR DESCRIPTION
## Summary
- We hit `/cable` failures in production after upgrading Rails, with Action Cable requests crashing when tag handling ran through `ActionCable::Connection::TaggedLoggerProxy`.
- Root cause: this extension called `logger.tags` unconditionally, but newer logger wrappers used with Rails (for example `ActiveSupport::BroadcastLogger`) do not implement `#tags` even though they support `#tagged`.
- Fix: make tag extraction defensive by falling back to `[]` when `#tags` is unavailable, then keep existing `logger.tagged(*current_tags)` behavior.
- Added a regression test that covers both logger implementations:
  - logger supports `#tagged` but not `#tags`
  - logger supports both `#tagged` and `#tags` (duplicate tag removal still works)

## Test plan
- [x] `bundle exec ruby test/extensions/action_cable/tagged_logger_proxy_test.rb`