### PR TITLE
Add structured logging integration for Solid Queue

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -19,32 +19,38 @@ end
 appraise "rails_7.1.1" do
   gem "rails", "7.1.1"
   gem "sidekiq", "~> 7.0.9"
+  gem "solid_queue", "~> 1.4"
   gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails_7.1" do
   gem "rails", "~> 7.1.0"
   gem "sidekiq", "~> 7.1.6"
+  gem "solid_queue", "~> 1.4"
   gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails_7.1b" do
   gem "rails", "~> 7.1.0"
   gem "sidekiq", "~> 7.3.0"
+  gem "solid_queue", "~> 1.4"
   gem "sqlite3", "~> 1.4"
 end
 
 appraise "rails_7.2" do
   gem "rails", "~> 7.2.0"
   gem "sidekiq", "~> 7.2.4"
+  gem "solid_queue", "~> 1.4"
 end
 
 appraise "rails_8.0" do
   gem "rails", "~> 8.0.0"
   gem "sidekiq", "~> 7.2.4"
+  gem "solid_queue", "~> 1.4"
 end
 
 appraise "rails_8.1" do
   gem "rails", "~> 8.1.1"
   gem "sidekiq", "~> 7.2.4"
+  gem "solid_queue", "~> 1.4"
 end

--- a/gemfiles/rails_7.1.1.gemfile
+++ b/gemfiles/rails_7.1.1.gemfile
@@ -14,5 +14,6 @@ gem "rails", "7.1.1"
 gem "sidekiq", "~> 7.0.9"
 gem "sqlite3", "~> 1.4"
 gem "rubocop"
+gem "solid_queue", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -14,5 +14,6 @@ gem "rails", "~> 7.1.0"
 gem "sidekiq", "~> 7.1.6"
 gem "sqlite3", "~> 1.4"
 gem "rubocop"
+gem "solid_queue", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.1b.gemfile
+++ b/gemfiles/rails_7.1b.gemfile
@@ -14,5 +14,6 @@ gem "rails", "~> 7.1.0"
 gem "sidekiq", "~> 7.3.0"
 gem "sqlite3", "~> 1.4"
 gem "rubocop"
+gem "solid_queue", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -14,5 +14,6 @@ gem "rails", "~> 7.2.0"
 gem "sidekiq", "~> 7.2.4"
 gem "sqlite3"
 gem "rubocop"
+gem "solid_queue", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -14,5 +14,6 @@ gem "rails", "~> 8.0.0"
 gem "sidekiq", "~> 7.2.4"
 gem "sqlite3"
 gem "rubocop"
+gem "solid_queue", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -14,5 +14,6 @@ gem "rails", "~> 8.1.1"
 gem "sidekiq", "~> 7.2.4"
 gem "sqlite3"
 gem "rubocop"
+gem "solid_queue", "~> 1.4"
 
 gemspec path: "../"

--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -37,6 +37,10 @@ module RailsSemanticLogger
     autoload :Loggable, "rails_semantic_logger/sidekiq/loggable"
   end
 
+  module SolidQueue
+    autoload :LogSubscriber, "rails_semantic_logger/solid_queue/log_subscriber"
+  end
+
   autoload :Options, "rails_semantic_logger/options"
 
   # Swap an existing subscriber with a new one

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -136,6 +136,11 @@ module RailsSemanticLogger
         end
       end
 
+      # Replace the SolidQueue logger
+      if config.rails_semantic_logger.replace_solid_queue_logger && defined?(::SolidQueue) && ::SolidQueue.respond_to?(:logger=)
+        ::SolidQueue.logger = SemanticLogger[::SolidQueue]
+      end
+
       # Replace the Sidetiq logger
       Sidetiq.logger = SemanticLogger[Sidetiq] if defined?(Sidetiq) && Sidetiq.respond_to?(:logger=)
 
@@ -247,6 +252,15 @@ module RailsSemanticLogger
 
         if config.rails_semantic_logger.replace_sidekiq_logger && defined?(::Sidekiq)
           require("rails_semantic_logger/extensions/sidekiq/sidekiq")
+        end
+
+        # SolidQueue
+        if config.rails_semantic_logger.replace_solid_queue_logger && defined?(::SolidQueue::LogSubscriber)
+          RailsSemanticLogger.swap_subscriber(
+            ::SolidQueue::LogSubscriber,
+            RailsSemanticLogger::SolidQueue::LogSubscriber,
+            :solid_queue
+          )
         end
       end
 

--- a/lib/rails_semantic_logger/options.rb
+++ b/lib/rails_semantic_logger/options.rb
@@ -112,26 +112,31 @@ module RailsSemanticLogger
   # * Do not replace the Sidekiq logger with a Semantic Logger logger.
   #
   #     config.rails_semantic_logger.replace_sidekiq_logger = false
+  #
+  # * Do not replace the SolidQueue logger / log subscriber.
+  #
+  #     config.rails_semantic_logger.replace_solid_queue_logger = false
   class Options
     attr_accessor :semantic, :started, :processing, :rendered, :ap_options, :add_file_appender,
                   :quiet_assets, :format, :named_tags, :filter, :console_logger, :action_message_format,
-                  :replace_sidekiq_logger
+                  :replace_sidekiq_logger, :replace_solid_queue_logger
 
     # Setup default values
     def initialize
-      @semantic               = true
-      @started                = false
-      @processing             = false
-      @rendered               = false
-      @ap_options             = {multiline: false}
-      @add_file_appender      = true
-      @quiet_assets           = false
-      @format                 = :default
-      @named_tags             = nil
-      @filter                 = nil
-      @console_logger         = true
-      @action_message_format  = nil
-      @replace_sidekiq_logger = true
+      @semantic                   = true
+      @started                    = false
+      @processing                 = false
+      @rendered                   = false
+      @ap_options                 = {multiline: false}
+      @add_file_appender          = true
+      @quiet_assets               = false
+      @format                     = :default
+      @named_tags                 = nil
+      @filter                     = nil
+      @console_logger             = true
+      @action_message_format      = nil
+      @replace_sidekiq_logger     = true
+      @replace_solid_queue_logger = true
     end
   end
 end

--- a/lib/rails_semantic_logger/solid_queue/log_subscriber.rb
+++ b/lib/rails_semantic_logger/solid_queue/log_subscriber.rb
@@ -1,0 +1,176 @@
+module RailsSemanticLogger
+  module SolidQueue
+    class LogSubscriber < ::ActiveSupport::LogSubscriber
+      def dispatch_scheduled(event)
+        log_event(event, :debug, "Dispatch scheduled jobs", **event.payload.slice(:batch_size, :size))
+      end
+
+      def claim(event)
+        log_event(event, :debug, "Claim jobs", **event.payload.slice(:process_id, :job_ids, :claimed_job_ids, :size))
+      end
+
+      def release_many_claimed(event)
+        log_event(event, :info, "Release claimed jobs", **event.payload.slice(:size))
+      end
+
+      def fail_many_claimed(event)
+        log_event(event, :warn, "Fail claimed jobs", **event.payload.slice(:job_ids, :process_ids))
+      end
+
+      def release_claimed(event)
+        log_event(event, :info, "Release claimed job", **event.payload.slice(:job_id, :process_id))
+      end
+
+      def retry_all(event)
+        log_event(event, :debug, "Retry failed jobs", **event.payload.slice(:jobs_size, :size))
+      end
+
+      def retry(event)
+        log_event(event, :debug, "Retry failed job", **event.payload.slice(:job_id))
+      end
+
+      def discard_all(event)
+        log_event(event, :debug, "Discard jobs", **event.payload.slice(:jobs_size, :size, :status))
+      end
+
+      def discard(event)
+        log_event(event, :debug, "Discard job", **event.payload.slice(:job_id, :status))
+      end
+
+      def release_many_blocked(event)
+        log_event(event, :debug, "Unblock jobs", **event.payload.slice(:limit, :size))
+      end
+
+      def release_blocked(event)
+        log_event(event, :debug, "Release blocked job", **event.payload.slice(:job_id, :concurrency_key, :released))
+      end
+
+      def enqueue_recurring_task(event)
+        attributes      = event.payload.slice(:task, :active_job_id, :enqueue_error)
+        attributes[:at] = event.payload[:at]&.iso8601
+
+        if attributes[:active_job_id].nil? && event.payload[:skipped].nil?
+          log_event(event, :error, "Error enqueuing recurring task", **attributes)
+        elsif event.payload[:other_adapter]
+          log_event(event, :debug, "Enqueued recurring task outside Solid Queue", **attributes)
+        else
+          action = event.payload[:skipped].present? ? "Skipped recurring task – already dispatched" : "Enqueued recurring task"
+          log_event(event, :debug, action, **attributes)
+        end
+      end
+
+      def start_process(event)
+        process    = event.payload[:process]
+        attributes = process_attributes(process).merge(process.metadata)
+
+        log_event(event, :info, "Started #{process.kind}", **attributes)
+      end
+
+      def shutdown_process(event)
+        process    = event.payload[:process]
+        attributes = process_attributes(process).merge(process.metadata)
+
+        log_event(event, :info, "Shutdown #{process.kind}", **attributes)
+      end
+
+      def register_process(event)
+        process_kind = event.payload[:kind]
+        attributes   = event.payload.slice(:pid, :hostname, :process_id, :name)
+
+        if (error = event.payload[:error])
+          log_event(event, :warn, "Error registering #{process_kind}", exception: error, **attributes)
+        else
+          log_event(event, :debug, "Register #{process_kind}", **attributes)
+        end
+      end
+
+      def deregister_process(event)
+        process    = event.payload[:process]
+        attributes = {
+          process_id:        process.id,
+          pid:               process.pid,
+          hostname:          process.hostname,
+          name:              process.name,
+          last_heartbeat_at: process.last_heartbeat_at.iso8601,
+          claimed_size:      event.payload[:claimed_size],
+          pruned:            event.payload[:pruned]
+        }
+
+        if (error = event.payload[:error])
+          log_event(event, :warn, "Error deregistering #{process.kind}", exception: error, **attributes)
+        else
+          log_event(event, :debug, "Deregister #{process.kind}", **attributes)
+        end
+      end
+
+      def prune_processes(event)
+        log_event(event, :debug, "Prune dead processes", **event.payload.slice(:size))
+      end
+
+      def thread_error(event)
+        log_event(event, :error, "Error in thread", exception: event.payload[:error])
+      end
+
+      def graceful_termination(event)
+        attributes = event.payload.slice(:process_id, :supervisor_pid, :supervised_processes)
+
+        if event.payload[:shutdown_timeout_exceeded]
+          log_event(event, :warn, "Supervisor wasn't terminated gracefully - shutdown timeout exceeded", **attributes)
+        else
+          log_event(event, :info, "Supervisor terminated gracefully", **attributes)
+        end
+      end
+
+      def immediate_termination(event)
+        log_event(event, :info, "Supervisor terminated immediately",
+                  **event.payload.slice(:process_id, :supervisor_pid, :supervised_processes))
+      end
+
+      def unhandled_signal_error(event)
+        log_event(event, :error, "Received unhandled signal", **event.payload.slice(:signal))
+      end
+
+      def replace_fork(event)
+        supervisor_pid = event.payload[:supervisor_pid]
+        status         = event.payload[:status]
+        attributes     = event.payload.slice(:pid).merge(
+          status:          status.exitstatus || "no exit status set",
+          pid_from_status: status.pid,
+          signaled:        status.signaled?,
+          stopsig:         status.stopsig,
+          termsig:         status.termsig
+        )
+
+        if (replaced_fork = event.payload[:fork])
+          log_event(event, :info, "Replaced terminated #{replaced_fork.kind}",
+                    **attributes, hostname: replaced_fork.hostname, name: replaced_fork.name)
+        elsif supervisor_pid != 1 # Running Docker, possibly having some processes that have been reparented
+          log_event(event, :warn, "Tried to replace forked process but it had already died", **attributes)
+        end
+      end
+
+      private
+
+      def process_attributes(process)
+        {
+          pid:        process.pid,
+          hostname:   process.hostname,
+          process_id: process.process_id,
+          name:       process.name
+        }
+      end
+
+      def log_event(event, level, action, exception: nil, **attributes)
+        logger.public_send(level) do
+          msg = {message: action, payload: attributes, duration: event.duration}
+          msg[:exception] = exception if exception
+          msg
+        end
+      end
+
+      def logger
+        @logger ||= SemanticLogger["SolidQueue"]
+      end
+    end
+  end
+end

--- a/test/solid_queue_test.rb
+++ b/test/solid_queue_test.rb
@@ -1,0 +1,682 @@
+require_relative "test_helper"
+
+class SolidQueueTest < Minitest::Test
+  describe "SolidQueue" do
+    before do
+      skip "SolidQueue is not available" unless defined?(::SolidQueue)
+    end
+
+    let(:subscriber) { RailsSemanticLogger::SolidQueue::LogSubscriber.new }
+
+    let(:event) do
+      ActiveSupport::Notifications::Event.new(event_name, 5.seconds.ago, Time.zone.now, SecureRandom.uuid, payload)
+    end
+
+    describe "#claim" do
+      let(:event_name) { "claim.solid_queue" }
+      let(:payload) do
+        {process_id: 42, job_ids: [1, 2, 3], claimed_job_ids: [1, 2], size: 3}
+      end
+
+      it "logs a structured debug event" do
+        messages = semantic_logger_events do
+          subscriber.claim(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Claim jobs",
+          payload_includes: {
+            process_id:      42,
+            claimed_job_ids: [1, 2],
+            size:            3
+          }
+        )
+      end
+    end
+
+    describe "#release_many_claimed" do
+      let(:event_name) { "release_many_claimed.solid_queue" }
+      let(:payload) { {size: 5} }
+
+      it "logs at info level" do
+        messages = semantic_logger_events do
+          subscriber.release_many_claimed(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :info,
+          name:             "SolidQueue",
+          message:          "Release claimed jobs",
+          payload_includes: {size: 5}
+        )
+      end
+    end
+
+    describe "#fail_many_claimed" do
+      let(:event_name) { "fail_many_claimed.solid_queue" }
+      let(:payload) { {job_ids: [1, 2], process_ids: [10, 11]} }
+
+      it "logs at warn level" do
+        messages = semantic_logger_events do
+          subscriber.fail_many_claimed(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:   :warn,
+          name:    "SolidQueue",
+          message: "Fail claimed jobs"
+        )
+      end
+    end
+
+    describe "#thread_error" do
+      let(:event_name) { "thread_error.solid_queue" }
+      let(:payload) { {error: ArgumentError.new("boom")} }
+
+      it "passes the exception object through" do
+        messages = semantic_logger_events do
+          subscriber.thread_error(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:   :error,
+          name:    "SolidQueue",
+          message: "Error in thread"
+        )
+
+        exception = messages[0].exception
+        assert exception.is_a?(ArgumentError)
+        assert_equal "boom", exception.message
+      end
+    end
+
+    describe "#start_process" do
+      let(:event_name) { "start_process.solid_queue" }
+      let(:process_struct) { Struct.new(:pid, :hostname, :process_id, :name, :kind, :metadata) }
+      let(:process) do
+        process_struct.new(1234, "host.local", "abc-123", "worker-1", "Worker", {polling_interval: 0.1, queues: "default"})
+      end
+      let(:payload) { {process: process} }
+
+      it "merges process metadata into the payload" do
+        messages = semantic_logger_events do
+          subscriber.start_process(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :info,
+          name:             "SolidQueue",
+          message:          "Started Worker",
+          payload_includes: {
+            pid:              1234,
+            hostname:         "host.local",
+            process_id:       "abc-123",
+            name:             "worker-1",
+            polling_interval: 0.1,
+            queues:           "default"
+          }
+        )
+      end
+    end
+
+    describe "#enqueue_recurring_task" do
+      let(:event_name) { "enqueue_recurring_task.solid_queue" }
+
+      describe "on success" do
+        let(:payload) { {task: "my_task", active_job_id: "job-1", at: Time.zone.now} }
+
+        it "logs a debug event" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_recurring_task(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :debug,
+            name:             "SolidQueue",
+            message:          "Enqueued recurring task",
+            payload_includes: {task: "my_task", active_job_id: "job-1"}
+          )
+        end
+      end
+
+      describe "on error" do
+        let(:payload) { {task: "my_task", enqueue_error: "boom"} }
+
+        it "logs an error event" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_recurring_task(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :error,
+            name:             "SolidQueue",
+            message:          "Error enqueuing recurring task",
+            payload_includes: {task: "my_task", enqueue_error: "boom"}
+          )
+        end
+      end
+
+      describe "on another adapter" do
+        let(:at) { Time.zone.now }
+        let(:payload) { {task: "my_task", active_job_id: "job-1", other_adapter: true, at: at} }
+
+        it "logs that the task was enqueued outside Solid Queue" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_recurring_task(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :debug,
+            name:             "SolidQueue",
+            message:          "Enqueued recurring task outside Solid Queue",
+            payload_includes: {task: "my_task", active_job_id: "job-1", at: at.iso8601}
+          )
+        end
+      end
+
+      describe "when skipped" do
+        let(:payload) { {task: "my_task", skipped: true} }
+
+        it "logs that the task was skipped" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_recurring_task(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :debug,
+            name:             "SolidQueue",
+            message:          "Skipped recurring task – already dispatched",
+            payload_includes: {task: "my_task"}
+          )
+        end
+      end
+    end
+
+    describe "#dispatch_scheduled" do
+      let(:event_name) { "dispatch_scheduled.solid_queue" }
+      let(:payload) { {batch_size: 100, size: 7} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.dispatch_scheduled(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Dispatch scheduled jobs",
+          payload_includes: {batch_size: 100, size: 7}
+        )
+      end
+    end
+
+    describe "#release_claimed" do
+      let(:event_name) { "release_claimed.solid_queue" }
+      let(:payload) { {job_id: 1, process_id: 42} }
+
+      it "logs at info level" do
+        messages = semantic_logger_events do
+          subscriber.release_claimed(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :info,
+          name:             "SolidQueue",
+          message:          "Release claimed job",
+          payload_includes: {job_id: 1, process_id: 42}
+        )
+      end
+    end
+
+    describe "#retry_all" do
+      let(:event_name) { "retry_all.solid_queue" }
+      let(:payload) { {jobs_size: 10, size: 8} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.retry_all(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Retry failed jobs",
+          payload_includes: {jobs_size: 10, size: 8}
+        )
+      end
+    end
+
+    describe "#retry" do
+      let(:event_name) { "retry.solid_queue" }
+      let(:payload) { {job_id: 99} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.retry(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Retry failed job",
+          payload_includes: {job_id: 99}
+        )
+      end
+    end
+
+    describe "#discard_all" do
+      let(:event_name) { "discard_all.solid_queue" }
+      let(:payload) { {jobs_size: 10, size: 8, status: "failed"} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.discard_all(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Discard jobs",
+          payload_includes: {jobs_size: 10, size: 8, status: "failed"}
+        )
+      end
+    end
+
+    describe "#discard" do
+      let(:event_name) { "discard.solid_queue" }
+      let(:payload) { {job_id: 99, status: "failed"} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.discard(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Discard job",
+          payload_includes: {job_id: 99, status: "failed"}
+        )
+      end
+    end
+
+    describe "#release_many_blocked" do
+      let(:event_name) { "release_many_blocked.solid_queue" }
+      let(:payload) { {limit: 50, size: 3} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.release_many_blocked(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Unblock jobs",
+          payload_includes: {limit: 50, size: 3}
+        )
+      end
+    end
+
+    describe "#release_blocked" do
+      let(:event_name) { "release_blocked.solid_queue" }
+      let(:payload) { {job_id: 99, concurrency_key: "key-1", released: true} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.release_blocked(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Release blocked job",
+          payload_includes: {job_id: 99, concurrency_key: "key-1", released: true}
+        )
+      end
+    end
+
+    describe "#shutdown_process" do
+      let(:event_name) { "shutdown_process.solid_queue" }
+      let(:process_struct) { Struct.new(:pid, :hostname, :process_id, :name, :kind, :metadata) }
+      let(:process) do
+        process_struct.new(1234, "host.local", "abc-123", "worker-1", "Worker", {polling_interval: 0.1, queues: "default"})
+      end
+      let(:payload) { {process: process} }
+
+      it "merges process metadata into the payload" do
+        messages = semantic_logger_events do
+          subscriber.shutdown_process(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :info,
+          name:             "SolidQueue",
+          message:          "Shutdown Worker",
+          payload_includes: {
+            pid:              1234,
+            hostname:         "host.local",
+            process_id:       "abc-123",
+            name:             "worker-1",
+            polling_interval: 0.1,
+            queues:           "default"
+          }
+        )
+      end
+    end
+
+    describe "#register_process" do
+      let(:event_name) { "register_process.solid_queue" }
+
+      describe "on success" do
+        let(:payload) { {kind: "Worker", pid: 1234, hostname: "host.local", process_id: "abc-123", name: "worker-1"} }
+
+        it "logs a debug event" do
+          messages = semantic_logger_events do
+            subscriber.register_process(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :debug,
+            name:             "SolidQueue",
+            message:          "Register Worker",
+            payload_includes: {pid: 1234, hostname: "host.local", process_id: "abc-123", name: "worker-1"}
+          )
+        end
+      end
+
+      describe "on error" do
+        let(:payload) do
+          {kind: "Worker", pid: 1234, hostname: "host.local", process_id: "abc-123", name: "worker-1",
+           error: ArgumentError.new("boom")}
+        end
+
+        it "logs a warning with the exception" do
+          messages = semantic_logger_events do
+            subscriber.register_process(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:     :warn,
+            name:      "SolidQueue",
+            message:   "Error registering Worker",
+            exception: ArgumentError
+          )
+          assert_equal "boom", messages[0].exception.message
+        end
+      end
+    end
+
+    describe "#deregister_process" do
+      let(:event_name) { "deregister_process.solid_queue" }
+      let(:process_struct) { Struct.new(:id, :pid, :hostname, :name, :last_heartbeat_at, :kind) }
+      let(:heartbeat) { Time.zone.now }
+      let(:process) do
+        process_struct.new(7, 1234, "host.local", "worker-1", heartbeat, "Worker")
+      end
+
+      describe "on success" do
+        let(:payload) { {process: process, claimed_size: 2, pruned: false} }
+
+        it "logs a debug event" do
+          messages = semantic_logger_events do
+            subscriber.deregister_process(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :debug,
+            name:             "SolidQueue",
+            message:          "Deregister Worker",
+            payload_includes: {
+              process_id:        7,
+              pid:               1234,
+              hostname:          "host.local",
+              name:              "worker-1",
+              last_heartbeat_at: heartbeat.iso8601,
+              claimed_size:      2,
+              pruned:            false
+            }
+          )
+        end
+      end
+
+      describe "on error" do
+        let(:payload) { {process: process, claimed_size: 2, pruned: false, error: ArgumentError.new("boom")} }
+
+        it "logs a warning with the exception" do
+          messages = semantic_logger_events do
+            subscriber.deregister_process(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:     :warn,
+            name:      "SolidQueue",
+            message:   "Error deregistering Worker",
+            exception: ArgumentError
+          )
+          assert_equal "boom", messages[0].exception.message
+        end
+      end
+    end
+
+    describe "#prune_processes" do
+      let(:event_name) { "prune_processes.solid_queue" }
+      let(:payload) { {size: 3} }
+
+      it "logs a debug event" do
+        messages = semantic_logger_events do
+          subscriber.prune_processes(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :debug,
+          name:             "SolidQueue",
+          message:          "Prune dead processes",
+          payload_includes: {size: 3}
+        )
+      end
+    end
+
+    describe "#graceful_termination" do
+      let(:event_name) { "graceful_termination.solid_queue" }
+
+      describe "when it completes in time" do
+        let(:payload) { {process_id: "abc-123", supervisor_pid: 1234, supervised_processes: [1, 2]} }
+
+        it "logs at info level" do
+          messages = semantic_logger_events do
+            subscriber.graceful_termination(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :info,
+            name:             "SolidQueue",
+            message:          "Supervisor terminated gracefully",
+            payload_includes: {process_id: "abc-123", supervisor_pid: 1234, supervised_processes: [1, 2]}
+          )
+        end
+      end
+
+      describe "when the shutdown timeout is exceeded" do
+        let(:payload) do
+          {process_id: "abc-123", supervisor_pid: 1234, supervised_processes: [1, 2], shutdown_timeout_exceeded: true}
+        end
+
+        it "logs at warn level" do
+          messages = semantic_logger_events do
+            subscriber.graceful_termination(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :warn,
+            name:             "SolidQueue",
+            message:          "Supervisor wasn't terminated gracefully - shutdown timeout exceeded",
+            payload_includes: {process_id: "abc-123", supervisor_pid: 1234}
+          )
+        end
+      end
+    end
+
+    describe "#immediate_termination" do
+      let(:event_name) { "immediate_termination.solid_queue" }
+      let(:payload) { {process_id: "abc-123", supervisor_pid: 1234, supervised_processes: [1, 2]} }
+
+      it "logs at info level" do
+        messages = semantic_logger_events do
+          subscriber.immediate_termination(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :info,
+          name:             "SolidQueue",
+          message:          "Supervisor terminated immediately",
+          payload_includes: {process_id: "abc-123", supervisor_pid: 1234, supervised_processes: [1, 2]}
+        )
+      end
+    end
+
+    describe "#unhandled_signal_error" do
+      let(:event_name) { "unhandled_signal_error.solid_queue" }
+      let(:payload) { {signal: "SIGKILL"} }
+
+      it "logs at error level" do
+        messages = semantic_logger_events do
+          subscriber.unhandled_signal_error(event)
+        end
+        assert_equal 1, messages.count, messages
+
+        assert_semantic_logger_event(
+          messages[0],
+          level:            :error,
+          name:             "SolidQueue",
+          message:          "Received unhandled signal",
+          payload_includes: {signal: "SIGKILL"}
+        )
+      end
+    end
+
+    describe "#replace_fork" do
+      let(:event_name) { "replace_fork.solid_queue" }
+      let(:status_struct) do
+        Struct.new(:exitstatus, :pid, :signaled, :stopsig, :termsig) do
+          def signaled?
+            signaled
+          end
+        end
+      end
+      let(:status) { status_struct.new(0, 4321, false, nil, nil) }
+
+      describe "when the terminated fork is known" do
+        let(:fork_struct) { Struct.new(:kind, :hostname, :name) }
+        let(:fork) { fork_struct.new("Worker", "host.local", "worker-1") }
+        let(:payload) { {supervisor_pid: 1234, status: status, pid: 4321, fork: fork} }
+
+        it "logs at info level with the fork details" do
+          messages = semantic_logger_events do
+            subscriber.replace_fork(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :info,
+            name:             "SolidQueue",
+            message:          "Replaced terminated Worker",
+            payload_includes: {
+              pid:             4321,
+              status:          0,
+              pid_from_status: 4321,
+              signaled:        false,
+              hostname:        "host.local",
+              name:            "worker-1"
+            }
+          )
+        end
+      end
+
+      describe "when the fork had already died" do
+        let(:payload) { {supervisor_pid: 1234, status: status, pid: 4321, fork: nil} }
+
+        it "logs a warning" do
+          messages = semantic_logger_events do
+            subscriber.replace_fork(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :warn,
+            name:             "SolidQueue",
+            message:          "Tried to replace forked process but it had already died",
+            payload_includes: {pid: 4321, status: 0, pid_from_status: 4321}
+          )
+        end
+      end
+
+      describe "when reparented under Docker (supervisor pid 1)" do
+        let(:payload) { {supervisor_pid: 1, status: status, pid: 4321, fork: nil} }
+
+        it "does not log anything" do
+          messages = semantic_logger_events do
+            subscriber.replace_fork(event)
+          end
+          assert_equal 0, messages.count, messages
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement structured logging by duplicating `SolidQueue::LogSubscriber` from Solid Queue v1.4.0 almost as-is, and modifying only its output format.

Similar to the Sidekiq integration, this introduces the `config.rails_semantic_logger.replace_solid_queue_logger` option to allow users to opt out.

Since Solid Queue requires Rails 7.1 or higher, the gem has been added only to the Appraisal and CI Gemfiles for Rails 7.1+.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
