### PR TITLE
Add enqueue_all logging to ActiveJob log subscriber

### DIFF
--- a/lib/rails_semantic_logger/active_job/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_job/log_subscriber.rb
@@ -67,7 +67,43 @@ module RailsSemanticLogger
         end
       end
 
+      def enqueue_all(event)
+        jobs           = event.payload[:jobs]
+        adapter        = event.payload[:adapter]
+        enqueued_count = event.payload[:enqueued_count].to_i
+        adapter_name   = ::ActiveJob.adapter_name(adapter)
+        failed_count   = jobs.size - enqueued_count
+
+        message =
+          if failed_count.zero?
+            enqueued_jobs_message(adapter_name, jobs)
+          elsif jobs.any?(&:successfully_enqueued?)
+            "#{enqueued_jobs_message(adapter_name, jobs.select(&:successfully_enqueued?))}. " \
+              "Failed enqueuing #{failed_count} #{'job'.pluralize(failed_count)}"
+          else
+            "Failed enqueuing #{failed_count} #{'job'.pluralize(failed_count)} to #{adapter_name}"
+          end
+
+        logger.info(
+          message: message,
+          payload: {
+            event_name:     event.name,
+            adapter:        adapter_name,
+            enqueued_count: enqueued_count,
+            total_count:    jobs.size,
+            job_classes:    jobs.map { |job| job.class.name }.tally
+          }
+        )
+      end
+
       private
+
+      def enqueued_jobs_message(adapter_name, enqueued_jobs)
+        enqueued_count     = enqueued_jobs.size
+        job_classes_counts = enqueued_jobs.map(&:class).tally.sort_by { |_k, v| -v }
+        "Enqueued #{enqueued_count} #{'job'.pluralize(enqueued_count)} to #{adapter_name} " \
+          "(#{job_classes_counts.map { |klass, count| "#{count} #{klass}" }.join(', ')})"
+      end
 
       class EventFormatter
         def initialize(event:, log_duration: false)

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -259,6 +259,87 @@ class ActiveJobTest < Minitest::Test
         end
       end
 
+      describe "#enqueue_all" do
+        before do
+          skip "enqueue_all requires Rails 7.1+" unless Rails.version.to_f >= 7.1
+        end
+
+        let(:event_name) { "enqueue_all.active_job" }
+
+        let(:adapter) { ActiveJob::QueueAdapters::InlineAdapter.new }
+
+        let(:jobs) { [MyJob.new("a"), MyJob.new("b")] }
+
+        let(:enqueued_count) { jobs.size }
+
+        let(:payload) do
+          {
+            adapter:        adapter,
+            jobs:           jobs,
+            enqueued_count: enqueued_count
+          }
+        end
+
+        it "logs an info message with the enqueued count" do
+          messages = semantic_logger_events do
+            subscriber.enqueue_all(event)
+          end
+          assert_equal 1, messages.count, messages
+
+          assert_semantic_logger_event(
+            messages[0],
+            level:            :info,
+            name:             "Rails",
+            message_includes: "Enqueued 2 jobs to Inline",
+            payload_includes: {
+              adapter:        "Inline",
+              enqueued_count: 2,
+              total_count:    2,
+              event_name:     "enqueue_all.active_job"
+            }
+          )
+          assert_equal({"ActiveJobTest::MyJob" => 2}, messages[0].payload[:job_classes])
+        end
+
+        describe "with partial failure" do
+          let(:enqueued_count) { 1 }
+
+          before do
+            jobs[0].successfully_enqueued = true
+            jobs[1].successfully_enqueued = false
+          end
+
+          it "logs an info message including the failed count" do
+            messages = semantic_logger_events do
+              subscriber.enqueue_all(event)
+            end
+            assert_equal 1, messages.count, messages
+            assert_equal :info, messages[0].level
+            assert_match(/Failed enqueuing 1 job/, messages[0].message)
+            assert_equal 1, messages[0].payload[:enqueued_count]
+            assert_equal 2, messages[0].payload[:total_count]
+          end
+        end
+
+        describe "with total failure" do
+          let(:enqueued_count) { 0 }
+
+          before do
+            jobs.each { |job| job.successfully_enqueued = false }
+          end
+
+          it "logs an info message reporting all jobs failed" do
+            messages = semantic_logger_events do
+              subscriber.enqueue_all(event)
+            end
+            assert_equal 1, messages.count, messages
+            assert_equal :info, messages[0].level
+            assert_match(/\AFailed enqueuing 2 jobs to Inline/, messages[0].message)
+            assert_equal 0, messages[0].payload[:enqueued_count]
+          end
+        end
+      end
+
       describe "ActiveJob::Logging::LogSubscriber::EventFormatter" do
         let(:formatter) do
           RailsSemanticLogger::ActiveJob::LogSubscriber::EventFormatter.new(event: event, log_duration: true)


### PR DESCRIPTION
### Issue # (if available)
None.

### Description of changes
`ActiveJob.perform_all_later` fires a single `enqueue_all.active_job` notification that RailsSemanticLogger's subscriber never handled. Since the gem unsubscribes Rails' default subscriber (which does handle it), bulk enqueues produced no log output at all.

Rails' default subscriber does handle this event:
https://github.com/rails/rails/blob/v8.1.0/activejob/lib/active_job/log_subscriber.rb#L49-L74

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
