### PR TITLE
Log cpu_time and idle_time in server request logs

### DIFF
--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -25,6 +25,12 @@ module RailsSemanticLogger
 
       def process_action(event)
         controller_logger(event).info do
+          # `event.payload` is shared with every other subscriber on this notification, so we work on
+          # a copy. A shallow `dup` is sufficient: only mutate `payload` via top-level key reassignment
+          # (e.g. `payload[:format] = ...`) or by writing into a freshly-created hash (e.g. the `.except`
+          # result below). Never mutate a nested object that still belongs to the original payload
+          # (e.g. `payload[:foo][:bar] = ...` on an unduped key), or the change will leak back into the
+          # shared payload and corrupt what other subscribers see.
           payload = event.payload.dup
 
           # Unused, but needed for Devise 401 status code monkey patch to still work.
@@ -63,6 +69,8 @@ module RailsSemanticLogger
           end
 
           payload[:allocations] = event.allocations
+          payload[:cpu_time]    = event.cpu_time.round(2)
+          payload[:idle_time]   = event.idle_time.round(2)
           payload[:gc_time]     = event.gc_time.round(2) if event.respond_to?(:gc_time)
 
           payload[:status_message] = ::Rack::Utils::HTTP_STATUS_CODES[payload[:status]] if payload[:status].present?

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -22,6 +22,30 @@ class ActionControllerTest < Minitest::Test
 
         assert_equal 1, messages.count, messages
       end
+
+      it "includes cpu_time and idle_time in the payload" do
+        event = ActiveSupport::Notifications::Event.new(
+          "process_action.action_controller",
+          5.seconds.ago,
+          Time.zone.now,
+          SecureRandom.uuid,
+          {
+            controller: "ArticlesController",
+            action:     "index",
+            status:     200
+          }
+        )
+
+        messages = semantic_logger_events do
+          subscriber.process_action(event)
+        end
+
+        assert_equal 1, messages.count, messages
+        payload = messages[0].payload
+
+        assert_instance_of Float, payload[:cpu_time]
+        assert_instance_of Float, payload[:idle_time]
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #274.

Adds `cpu_time` and `idle_time` to the `process_action.action_controller` log payload, alongside the existing `allocations` and `gc_time` fields. These come straight off the `ActiveSupport::Notifications::Event` object, so server request logs now carry all four runtime metrics requested in the issue (`gc_time` and `allocations` were already present).

```ruby
payload[:cpu_time]  = event.cpu_time.round(2)
payload[:idle_time] = event.idle_time.round(2)
```

## Notes

- No `respond_to?` guard is needed: `cpu_time`/`idle_time` exist on the Event API across the entire supported matrix (Rails 7.2/8.0/8.1). `gc_time` keeps its existing guard since it is newer.
- These values are populated with real numbers because this gem attaches its subscribers via the `LogSubscriber#attach_to` path, which captures CPU timing. `idle_time` is `duration - cpu_time` (time spent waiting on I/O).
- The PR also carries a clarifying comment (already present in the working tree) about why `process_action` works on a `dup` of the shared event payload.

## Test

Added a `#process_action` test asserting `cpu_time` and `idle_time` land in the payload as Floats. Existing tests and RuboCop pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)