### PR TITLE
Include Sidekiq job class in log tags (#256)

### DIFF
--- a/lib/rails_semantic_logger/extensions/sidekiq/sidekiq.rb
+++ b/lib/rails_semantic_logger/extensions/sidekiq/sidekiq.rb
@@ -17,7 +17,7 @@ module Sidekiq
       end
 
       def self.job_hash_context(job_hash)
-        h         = {jid: job_hash["jid"]}
+        h         = {jid: job_hash["jid"], class: job_hash["wrapped"] || job_hash["class"]}
         h[:bid]   = job_hash["bid"] if job_hash["bid"]
         h[:queue] = job_hash["queue"] if job_hash["queue"]
         h
@@ -30,7 +30,7 @@ module Sidekiq
     # Convert string to machine readable format
     class Processor
       def log_context(job_hash)
-        h         = {jid: job_hash["jid"]}
+        h         = {jid: job_hash["jid"], class: job_hash["wrapped"] || job_hash["class"]}
         h[:bid]   = job_hash["bid"] if job_hash["bid"]
         h[:queue] = job_hash["queue"] if job_hash["queue"]
         h

--- a/lib/rails_semantic_logger/sidekiq/job_logger.rb
+++ b/lib/rails_semantic_logger/sidekiq/job_logger.rb
@@ -60,7 +60,7 @@ module RailsSemanticLogger
       end
 
       def job_hash_context(job_hash)
-        h         = {jid: job_hash["jid"]}
+        h         = {jid: job_hash["jid"], class: job_hash["wrapped"] || job_hash["class"]}
         h[:bid]   = job_hash["bid"] if job_hash["bid"]
         h[:tags]  = job_hash["tags"] if job_hash["tags"]
         h[:queue] = job_hash["queue"] if job_hash["queue"]

--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -59,7 +59,7 @@ class SidekiqTest < Minitest::Test
           name:       "SimpleJob",
           message:    "Start #perform",
           metric:     "sidekiq.queue.latency",
-          named_tags: {jid: nil, queue: "default"}
+          named_tags: {jid: nil, class: "SimpleJob", queue: "default"}
         )
         assert_kind_of Float, messages[0].metric_amount
 
@@ -69,7 +69,7 @@ class SidekiqTest < Minitest::Test
           name:       "SimpleJob",
           message:    "Completed #perform",
           metric:     "sidekiq.job.perform",
-          named_tags: {jid: nil, queue: "default"}
+          named_tags: {jid: nil, class: "SimpleJob", queue: "default"}
         )
         assert_kind_of Float, messages[1].duration
       end
@@ -92,7 +92,7 @@ class SidekiqTest < Minitest::Test
           name:       "SimpleJob",
           message:    "Start #perform",
           metric:     "sidekiq.queue.latency",
-          named_tags: {jid: nil, queue: "default"}
+          named_tags: {jid: nil, class: "SimpleJob", queue: "default"}
         )
         # Sidekiq 8+ returns Integer latency, whereas earlier versions return Float
         assert_kind_of Numeric, messages[0].metric_amount
@@ -103,7 +103,7 @@ class SidekiqTest < Minitest::Test
           name:       "SimpleJob",
           message:    "Completed #perform",
           metric:     "sidekiq.job.perform",
-          named_tags: {jid: nil, queue: "default"}
+          named_tags: {jid: nil, class: "SimpleJob", queue: "default"}
         )
         assert_kind_of Float, messages[1].duration
       end
@@ -127,7 +127,7 @@ class SidekiqTest < Minitest::Test
             name:       "BadJob",
             message:    "Start #perform",
             metric:     "sidekiq.queue.latency",
-            named_tags: {jid: nil, queue: "default"},
+            named_tags: {jid: nil, class: "BadJob", queue: "default"},
             exception:  :nil
           )
           assert_kind_of Float, messages[0].metric_amount
@@ -138,7 +138,7 @@ class SidekiqTest < Minitest::Test
             name:       "BadJob",
             message:    "Completed #perform",
             metric:     "sidekiq.job.perform",
-            named_tags: {jid: nil, queue: "default"},
+            named_tags: {jid: nil, class: "BadJob", queue: "default"},
             exception:  ArgumentError
           )
           assert_kind_of Float, messages[1].duration


### PR DESCRIPTION
Fixes #256.

## Problem

Sidekiq's stock logger tags every line with the job class (`class=SimpleWorker`). This gem only tagged jobs with `jid`/`queue`, so when a job emitted a nested log line from ActiveRecord/Rails/etc., you could see the `jid` but not which job class produced it. The job class only appeared as the logger *name* on the job's own `Start/Completed #perform` lines, not on nested lines from other components.

## Change

Add the job class to the named tags that wrap the entire job execution (`job_hash_context` / legacy `log_context`), so every line emitted during a job carries `class:`, matching Sidekiq's default logger behavior.

- Uses `wrapped || class` to report the real class for ActiveJob-wrapped jobs, mirroring the logger selection already done in `#call`.
- Applied to the current `Sidekiq::JobLogger` and the legacy Sidekiq v4/v5 extension methods for consistency.
- Updated the `named_tags` assertions in `test/sidekiq_test.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)