### PR TITLE
Add test for disabling Sidekiq perform messages

### DIFF
--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -108,6 +108,18 @@ class SidekiqTest < Minitest::Test
         assert_kind_of Float, messages[1].duration
       end
 
+      it "does not emit perform messages when disabled" do
+        RailsSemanticLogger::Sidekiq::JobLogger.perform_messages = false
+
+        messages = semantic_logger_events do
+          processor.send(:process, uow)
+        end
+
+        assert_equal 0, messages.count, -> { messages.collect(&:to_h).ai }
+      ensure
+        RailsSemanticLogger::Sidekiq::JobLogger.perform_messages = true
+      end
+
       describe "with Bad Job" do
         let(:job) { BadJob }
 


### PR DESCRIPTION
Adds a test covering `RailsSemanticLogger::Sidekiq::JobLogger.perform_messages = false` (the opt-out added in #283), asserting that no `Start #perform` / `Completed #perform` events are emitted while the job still runs.

Resolves #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)