### PR TITLE
Log Sidekiq error handler context at :info to match current Sidekiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add a toggle to prevent replacement of the Sidekiq logger (`replace_sidekiq_logger`).
 - Add configuration to toggle off Sidekiq "perform" messages.
+- Sidekiq: log the replacement error handler's context at `:info` instead of `:warn`, matching
+  upstream Sidekiq's default handler and removing duplicate noise (the exception itself is already
+  logged at `:error` by the Job Logger). Fixes #271.
 - Handle binary strings in `EventFormatter#format`. Fixes #284.
 - Fix `Started` log line under Rails 7.1, with backward compatibility back to Rails 7.2. Fixes #281.
 - Fix #282. Thanks @navidemad.

--- a/lib/rails_semantic_logger/sidekiq/defaults.rb
+++ b/lib/rails_semantic_logger/sidekiq/defaults.rb
@@ -2,6 +2,8 @@ module RailsSemanticLogger
   module Sidekiq
     module Defaults
       # Prevent exception logging during standard error handling since the Job Logger below already logs the exception.
+      # Logs the remaining Sidekiq context at :info (matching upstream Sidekiq's default handler) rather than :warn,
+      # since the exception itself is already logged at :error by the Job Logger.
       ERROR_HANDLER =
         if ::Sidekiq::VERSION.to_f < 7.1 ||
            (::Sidekiq::VERSION.to_f == 7.1 && ::Sidekiq::VERSION.split(".").last.to_i < 6)
@@ -10,7 +12,7 @@ module RailsSemanticLogger
               job_hash = ctx[:job] || {}
               klass    = job_hash["display_class"] || job_hash["wrapped"] || job_hash["class"]
               logger   = klass ? SemanticLogger[klass] : ::Sidekiq.logger
-              ctx[:context] ? logger.warn(ctx[:context], ctx) : logger.warn(ctx)
+              ctx[:context] ? logger.info(ctx[:context], ctx) : logger.info(ctx)
             end
           end
         else
@@ -19,7 +21,7 @@ module RailsSemanticLogger
               job_hash = ctx[:job] || {}
               klass    = job_hash["display_class"] || job_hash["wrapped"] || job_hash["class"]
               logger   = klass ? SemanticLogger[klass] : ::Sidekiq.logger
-              ctx[:context] ? logger.warn(ctx[:context], ctx) : logger.warn(ctx)
+              ctx[:context] ? logger.info(ctx[:context], ctx) : logger.info(ctx)
             end
           end
         end

--- a/test/sidekiq_test.rb
+++ b/test/sidekiq_test.rb
@@ -157,7 +157,7 @@ class SidekiqTest < Minitest::Test
 
           assert_semantic_logger_event(
             messages[2],
-            level:            :warn,
+            level:            :info,
             name:             "BadJob",
             message:          "Job raised exception",
             payload_includes: {context: "Job raised exception"},


### PR DESCRIPTION
## Summary

Fixes #271.

The replacement Sidekiq error handler logged its context at `:warn`. That level matched Sidekiq 7.2's own default handler when this code was written, but upstream Sidekiq has since moved its default handler down to `:info` (current `main`/8.x logs via `cfg.logger.info`), so the `:warn` had drifted from upstream.

The handler intentionally does **not** re-log the exception itself, because the job logger already logs it at `:error` with a full backtrace. The only thing the handler emits is the remaining Sidekiq context, and emitting that at `:warn` duplicated, at a higher level, what the job logger already reports.

This changes both `ERROR_HANDLER` lambdas (the pre-7.1.6 and 7.1.6+ variants) to log the context at `:info`, matching current Sidekiq behavior and removing the duplicate `:warn` noise. The exception still appears once, at `:error`, from the job logger.

## Notes

- Users who relied on these context lines appearing at `:warn` should lower their Sidekiq logger to `:info`. A matching upgrade note was added to the v4→v5 migration docs in the `semantic_logger` repo (`docs/rails.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)