### PR TITLE
Warn when logger settings are configured too late to take effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   (derived from `config.filter_parameters`), replacing the previous partial filter that only
   handled a single leading Regexp. The upstream subscriber is identical across Rails 7.2 / 8.0 /
   8.1, so no version-specific behavior is required.
+- Warn when a logger setting is configured too late to take effect. Settings consumed while the
+  logger is built (the appenders block, `filter`, `format`, `ap_options`, `add_file_appender`,
+  `semantic`, `replace_sidekiq_logger`, `replace_solid_queue_logger`) now print a warning when
+  changed from `config/initializers/*`, which Rails loads *after* the logger is initialized.
+  Settings consumed at the end of initialization (`started`, `processing`, `rendered`,
+  `quiet_assets`, `action_message_format`) warn when changed after the application has booted.
+  Configure logging in `config/application.rb` or `config/environments/<env>.rb`. Addresses #245.
+- Remove the long-deprecated and unused `named_tags` option. Supply a Hash to `config.log_tags`
+  instead.
 
 ## [4.20.0] - 2026-04-10
 

--- a/lib/rails_semantic_logger.rb
+++ b/lib/rails_semantic_logger.rb
@@ -50,6 +50,23 @@ module RailsSemanticLogger
     @deprecator ||= ActiveSupport::Deprecation.new("6.0", "rails_semantic_logger")
   end
 
+  # Warn that a setting was changed too late to take effect, so the change has no
+  # effect. When `config_initializers_too_late` is true (the default), the setting
+  # is consumed while the logger is built, *before* `config/initializers/*` is
+  # loaded, so that location is called out as too late. When false, the setting is
+  # consumed at the end of initialization (`config/initializers/*` still works) and
+  # only a change after the application has booted is too late.
+  def self.warn_initialized_too_late(setting, config_initializers_too_late: true)
+    env       = defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : "<env>"
+    locations = "`config/application.rb` or `config/environments/#{env}.rb`"
+    locations += " (or a `config/initializers/*` file)" unless config_initializers_too_late
+    suffix    = config_initializers_too_late ? "; `config/initializers/*` is loaded too late." : "."
+    warn(
+      "[rails_semantic_logger] `config.rails_semantic_logger.#{setting}` was set too late to take " \
+      "effect, so it has no effect. Set it in #{locations}#{suffix}"
+    )
+  end
+
   # Create the appenders declared via `config.rails_semantic_logger.appenders` with
   # `add_server` (or the default console appender when the application declared no
   # appenders of its own).

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -87,6 +87,10 @@ module RailsSemanticLogger
           logger
         end
 
+      # Logger and init-time appenders are now built; settings read above no
+      # longer take effect, so flag late changes (e.g. from config/initializers).
+      config.rails_semantic_logger.logger_initialized!
+
       # Replace Rails loggers
       %i[active_record action_controller action_mailer action_view].each do |name|
         ActiveSupport.on_load(name) { include SemanticLogger::Loggable }
@@ -302,6 +306,10 @@ module RailsSemanticLogger
         # Include method names on log entries in the console
         SemanticLogger.backtrace_level = SemanticLogger.default_level
       end
+
+      # Initialization is complete; the post-init settings have been consumed, so
+      # flag changes made after this point (e.g. at runtime) as having no effect.
+      config.rails_semantic_logger.fully_initialized!
     end
   end
 end

--- a/lib/rails_semantic_logger/options.rb
+++ b/lib/rails_semantic_logger/options.rb
@@ -107,10 +107,6 @@ module RailsSemanticLogger
   #
   #     config.rails_semantic_logger.filter = nil
   #
-  # * named_tags: *DEPRECATED*
-  #   Instead, supply a Hash to config.log_tags
-  #   config.rails_semantic_logger.named_tags = nil
-  #
   # * Change the message format of Action Controller action.
   #   A block that will be called to format the message.
   #   It is supplied with the `message` and `payload` and should return the formatted data.
@@ -127,12 +123,34 @@ module RailsSemanticLogger
   #
   #     config.rails_semantic_logger.replace_solid_queue_logger = false
   class Options
-    attr_accessor :semantic, :started, :processing, :rendered,
-                  :quiet_assets, :named_tags, :action_message_format,
-                  :replace_sidekiq_logger, :replace_solid_queue_logger
+    # Settings consumed while the logger itself is built, during Rails'
+    # `:initialize_logger` initializer. Changing them after that (e.g. from
+    # `config/initializers/*`, which Rails loads later) has no effect.
+    LOGGER_INIT_SETTINGS = %i[semantic replace_sidekiq_logger replace_solid_queue_logger].freeze
+
+    # Settings consumed as Rails finishes initializing (`config.after_initialize`),
+    # which runs *after* `config/initializers/*`. They may still be set there, but
+    # changing them after the application has booted has no effect.
+    POST_INIT_SETTINGS = %i[started processing rendered quiet_assets action_message_format].freeze
+
+    attr_reader(*LOGGER_INIT_SETTINGS, *POST_INIT_SETTINGS)
 
     # DEPRECATED: configure these on the appender instead, via #appenders.
     attr_reader :ap_options, :format, :filter, :console_logger, :add_file_appender
+
+    LOGGER_INIT_SETTINGS.each do |setting|
+      define_method("#{setting}=") do |value|
+        warn_if_logger_initialized(setting)
+        instance_variable_set(:"@#{setting}", value)
+      end
+    end
+
+    POST_INIT_SETTINGS.each do |setting|
+      define_method("#{setting}=") do |value|
+        warn_if_fully_initialized(setting)
+        instance_variable_set(:"@#{setting}", value)
+      end
+    end
 
     # Setup default values
     def initialize
@@ -144,7 +162,6 @@ module RailsSemanticLogger
       @add_file_appender          = true
       @quiet_assets               = false
       @format                     = :default
-      @named_tags                 = nil
       @filter                     = nil
       @console_logger             = true
       @action_message_format      = nil
@@ -182,7 +199,10 @@ module RailsSemanticLogger
     # longer used.
     def appenders
       @appenders ||= RailsSemanticLogger::Appenders.new
-      yield @appenders if block_given?
+      if block_given?
+        warn_if_logger_initialized(:appenders)
+        yield @appenders
+      end
       @appenders
     end
 
@@ -191,18 +211,37 @@ module RailsSemanticLogger
       defined?(@appenders) && @appenders.any?
     end
 
+    # Marks that Rails Semantic Logger has already built its logger and the
+    # init-time appenders. Called by the engine at the end of the
+    # `:initialize_logger` initializer. After this point, settings that are only
+    # read while building those appenders no longer have any effect, so changing
+    # them emits a warning (see #warn_if_logger_initialized).
+    def logger_initialized!
+      @logger_initialized = true
+    end
+
+    # Marks that Rails has finished initializing the application (the engine's
+    # `config.after_initialize` has run). Called by the engine. After this point,
+    # the POST_INIT_SETTINGS have already been consumed, so changing them warns.
+    def fully_initialized!
+      @fully_initialized = true
+    end
+
     def ap_options=(value)
       deprecate_appender_option(:ap_options)
+      warn_if_logger_initialized(:ap_options)
       @ap_options = value
     end
 
     def format=(value)
       deprecate_appender_option(:format)
+      warn_if_logger_initialized(:format)
       @format = value
     end
 
     def filter=(value)
       deprecate_appender_option(:filter)
+      warn_if_logger_initialized(:filter)
       @filter = value
     end
 
@@ -213,6 +252,7 @@ module RailsSemanticLogger
 
     def add_file_appender=(value)
       deprecate_appender_option(:add_file_appender)
+      warn_if_logger_initialized(:add_file_appender)
       @add_file_appender = value
     end
 
@@ -224,6 +264,25 @@ module RailsSemanticLogger
         "Declare the destination and formatting directly instead, via " \
         "`config.rails_semantic_logger.appenders { |appenders| #{via} }`."
       )
+    end
+
+    # Warn when an init-time setting is changed after the logger and its
+    # appenders have already been built. This is the classic footgun of putting
+    # logger configuration in `config/initializers/*`, which Rails loads *after*
+    # the logger is initialized, so the change silently has no effect.
+    def warn_if_logger_initialized(setting)
+      return unless defined?(@logger_initialized) && @logger_initialized
+
+      RailsSemanticLogger.warn_initialized_too_late(setting)
+    end
+
+    # Warn when a setting consumed at the end of Rails initialization is changed
+    # after the application has already booted. Unlike #warn_if_logger_initialized,
+    # `config/initializers/*` is *not* too late for these, so it is not suggested.
+    def warn_if_fully_initialized(setting)
+      return unless defined?(@fully_initialized) && @fully_initialized
+
+      RailsSemanticLogger.warn_initialized_too_late(setting, config_initializers_too_late: false)
     end
   end
 end

--- a/test/appenders_test.rb
+++ b/test/appenders_test.rb
@@ -177,6 +177,82 @@ class AppendersTest < Minitest::Test
         refute options.add_file_appender
       end
     end
+
+    describe "configured after the logger is initialized" do
+      it "does not warn before the logger is initialized" do
+        _out, err = capture_io do
+          options.appenders { |appenders| appenders.add(file_name: "log/test.log") }
+        end
+
+        refute_match(/too late|no effect/, err)
+      end
+
+      it "warns when an appender is declared too late but still records it" do
+        options.logger_initialized!
+
+        _out, err = capture_io do
+          options.appenders { |appenders| appenders.add(file_name: "log/test.log") }
+        end
+
+        assert_match(/no effect/, err)
+        assert_match(%r{config/initializers}, err)
+        assert_predicate options, :appenders?
+      end
+
+      it "does not warn when reading appenders without a block after initialization" do
+        options.logger_initialized!
+
+        _out, err = capture_io { options.appenders }
+
+        assert_empty err
+      end
+
+      it "warns when filter is set too late" do
+        options.logger_initialized!
+
+        _out, err = capture_io do
+          AppendersTest.capture_deprecations { options.filter = /MyClass/ }
+        end
+
+        assert_match(/filter.*no effect/m, err)
+      end
+
+      it "warns when a logger-init setting (semantic) is set after logger initialization" do
+        options.logger_initialized!
+
+        _out, err = capture_io { options.semantic = false }
+
+        assert_match(/semantic.*no effect/m, err)
+        assert_match(%r{config/initializers}, err)
+        refute options.semantic
+      end
+
+      it "does not warn for a post-init setting (started) merely after logger initialization" do
+        options.logger_initialized!
+
+        _out, err = capture_io { options.started = true }
+
+        assert_empty err
+        assert options.started
+      end
+
+      it "warns for a post-init setting (started) once the app is fully initialized" do
+        options.fully_initialized!
+
+        _out, err = capture_io { options.started = true }
+
+        assert_match(/started.*no effect/m, err)
+        assert options.started
+      end
+
+      it "does not tell post-init settings to avoid config/initializers" do
+        options.fully_initialized!
+
+        _out, err = capture_io { options.rendered = true }
+
+        refute_match(%r{`config/initializers/\*` is loaded too late}, err)
+      end
+    end
   end
 
   describe ".add_server_appenders" do


### PR DESCRIPTION
## Summary

Configuring Rails Semantic Logger from `config/initializers/*` is a common footgun: Rails builds the logger in its `:initialize_logger` initializer, which runs **before** `config/initializers/*` is loaded. Settings made there silently have no effect, or, when adding an appender, create one *in addition to* the default file appender rather than replacing it (duplicate, unfiltered output). This is the root cause of #245, where a health-check `filter` set in an initializer never applied.

This PR makes that failure mode visible by warning when a setting is changed after the point at which it is consumed, and removes the long-dead `named_tags` option.

## How it works

Two initialization milestones are tracked on `Options`, each guarding the settings consumed at that phase:

- **`logger_initialized!`** (end of `:initialize_logger`) — guards settings consumed while the logger is built: the appenders block, `filter`, `format`, `ap_options`, `add_file_appender`, `semantic`, `replace_sidekiq_logger`, `replace_solid_queue_logger`. `config/initializers/*` is too late for these, and the warning says so.
- **`fully_initialized!`** (end of `config.after_initialize`) — guards settings consumed as Rails finishes initializing: `started`, `processing`, `rendered`, `quiet_assets`, `action_message_format`. `config/initializers/*` is fine for these; only a change after the app has booted is too late, so the warning does **not** point at `config/initializers` for them.

The boundary for each option was determined by its actual read site in the engine, so correctly-placed configuration (`config/application.rb`, `config/environments/<env>.rb`, and for the post-init group also `config/initializers/*`) does not warn.

## Also

- Removes the long-deprecated and unused `named_tags` option. Supply a Hash to `config.log_tags` instead. (Since this is a v5/major change, the removal is hard rather than another deprecation.)

## Notes

- Documentation for this lives in the `semantic_logger` repo (`docs/rails.md`) and is handled in a separate PR there.
- `processing` is included in the post-init group for consistency, though it is currently not consumed by the engine (a pre-existing latent gap, not addressed here).

## Testing

- `bundle exec rake test` — 189 runs, 0 failures
- `rubocop` — clean
- New tests in `test/appenders_test.rb` cover both phases: logger-init settings warn after `logger_initialized!` (and mention `config/initializers`), post-init settings do **not** warn merely after `logger_initialized!` but **do** after `fully_initialized!`, and post-init warnings omit the `config/initializers`-too-late guidance.

Addresses #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)