### PR TITLE
Restore the processing option for the Processing message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Settings consumed at the end of initialization (`started`, `processing`, `rendered`,
   `quiet_assets`, `action_message_format`) warn when changed after the application has booted.
   Configure logging in `config/application.rb` or `config/environments/<env>.rb`. Addresses #245.
+- ActionController: restore the `processing` option, which had stopped taking effect. The
+  `Processing` message was hardcoded to `:debug`; it is now logged at `:info` again when
+  `config.rails_semantic_logger.processing` is true, matching the `started` and `rendered` options.
 - Remove the long-deprecated and unused `named_tags` option. Supply a Hash to `config.log_tags`
   instead.
 

--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -15,12 +15,15 @@ module RailsSemanticLogger
       class_attribute :backtrace_cleaner, default: ActiveSupport::BacktraceCleaner.new
 
       class << self
-        attr_accessor :action_message_format
+        attr_accessor :action_message_format, :processing_log_level
       end
 
-      # Log as debug to hide Processing messages in production
+      # Defaults to :debug so the Processing message is hidden in production. The engine raises it
+      # to :info when `config.rails_semantic_logger.processing` is true.
+      @processing_log_level = :debug
+
       def start_processing(event)
-        controller_logger(event).debug { action_message("Processing", event.payload) }
+        controller_logger(event).send(self.class.processing_log_level) { action_message("Processing", event.payload) }
       end
 
       def process_action(event)

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -239,8 +239,9 @@ module RailsSemanticLogger
         if defined?(::ActionController)
           require "action_controller/log_subscriber"
 
-          RailsSemanticLogger::ActionController::LogSubscriber.action_message_format =
-            config.rails_semantic_logger.action_message_format
+          subscriber                       = RailsSemanticLogger::ActionController::LogSubscriber
+          subscriber.action_message_format = config.rails_semantic_logger.action_message_format
+          subscriber.processing_log_level  = :info if config.rails_semantic_logger.processing
           RailsSemanticLogger.swap_subscriber(
             ::ActionController::LogSubscriber,
             RailsSemanticLogger::ActionController::LogSubscriber,

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -47,5 +47,55 @@ class ActionControllerTest < Minitest::Test
         assert_instance_of Float, payload[:idle_time]
       end
     end
+
+    describe "#start_processing" do
+      let(:event) do
+        ActiveSupport::Notifications::Event.new(
+          "start_processing.action_controller",
+          5.seconds.ago,
+          Time.zone.now,
+          SecureRandom.uuid,
+          {
+            controller: "ArticlesController",
+            action:     "index"
+          }
+        )
+      end
+
+      after do
+        # Restore the default so the option does not leak into other tests.
+        RailsSemanticLogger::ActionController::LogSubscriber.processing_log_level = :debug
+      end
+
+      it "logs the Processing message at :debug by default" do
+        RailsSemanticLogger::ActionController::LogSubscriber.processing_log_level = :debug
+
+        messages = semantic_logger_events do
+          subscriber.start_processing(event)
+        end
+
+        assert_equal 1, messages.count, messages
+        assert_semantic_logger_event(
+          messages[0],
+          level:   :debug,
+          message: "Processing #index"
+        )
+      end
+
+      it "logs the Processing message at :info when processing_log_level is :info" do
+        RailsSemanticLogger::ActionController::LogSubscriber.processing_log_level = :info
+
+        messages = semantic_logger_events do
+          subscriber.start_processing(event)
+        end
+
+        assert_equal 1, messages.count, messages
+        assert_semantic_logger_event(
+          messages[0],
+          level:   :info,
+          message: "Processing #index"
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

The `config.rails_semantic_logger.processing` option had stopped taking effect. ActionController's `start_processing` hardcoded the log level to `:debug`, so nothing read the option and the `Processing` message could no longer be surfaced in production.

This restores it by following the same pattern as the sibling `started` and `rendered` options: a configurable class-level `processing_log_level` that defaults to `:debug` and is raised to `:info` by the engine when `config.rails_semantic_logger.processing` is true.

## Changes

- **`action_controller/log_subscriber.rb`** — add a `processing_log_level` class accessor (default `:debug`); `start_processing` now sends that level instead of a hardcoded `.debug`.
- **`engine.rb`** — set `processing_log_level = :info` when `config.rails_semantic_logger.processing` is true, alongside the existing `action_message_format` wiring.
- **`test/action_controller_test.rb`** — add a `#start_processing` block covering both the default `:debug` level and the `:info` level when enabled.
- **`CHANGELOG.md`** — note the restored option in the unreleased `5.0.0` section.

## Behavior

- Default (`processing = false`): unchanged, `Processing` logged at `:debug` and hidden in production.
- `config.rails_semantic_logger.processing = true`: `Processing` logged at `:info` again, matching `started`/`rendered`.

## Testing

- `bundle exec ruby -Itest test/action_controller_test.rb test/controllers/dashboard_controller_test.rb` — passes.
- `rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)