### PR TITLE
Fix ActionCable TaggedLoggerProxy compatibility with Semantic Logger (#220)

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
+++ b/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
@@ -1,11 +1,52 @@
 require "action_cable/connection/tagged_logger_proxy"
 
+# Upstream source (identical across supported versions):
+#   https://github.com/rails/rails/blob/v7.2.2/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
+#   https://github.com/rails/rails/blob/v8.0.2/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
+#   https://github.com/rails/rails/blob/v8.1.3/actioncable/lib/action_cable/connection/tagged_logger_proxy.rb
 module ActionCable
   module Connection
     class TaggedLoggerProxy
+      # Mirrors upstream #tag, including the `respond_to?(:tagged)` guard so a
+      # target logger without tagging support (e.g. when handed a non-tagged
+      # ActiveRecord::Base.logger by the worker pool) simply yields. Diverges in
+      # one place: upstream reads the already-applied tags via
+      # `logger.formatter.current_tags` (ActiveSupport::TaggedLogging), but
+      # Semantic Logger exposes them via `#tags`, so resolve from whichever the
+      # target logger supports. See #220.
       def tag(logger, &)
-        current_tags = tags - (logger.respond_to?(:tags) ? Array(logger.tags) : [])
-        logger.tagged(*current_tags, &)
+        if logger.respond_to?(:tagged)
+          current_tags = tags - applied_tags_for(logger)
+          logger.tagged(*current_tags, &)
+        else
+          yield
+        end
+      end
+
+      # Upstream defines the severity methods with a single-arg signature
+      # (`message = nil`), which discards Semantic Logger's richer payload and
+      # exception arguments and raises ArgumentError when they are supplied.
+      # Redefine them to forward the full Semantic Logger signature down to the
+      # wrapped logger, while still applying the connection's tags. See #220.
+      %i[debug info warn error fatal unknown].each do |severity|
+        define_method(severity) do |message = nil, payload = nil, exception = nil, &block|
+          tag(@logger) { @logger.public_send(severity, message, payload, exception, &block) }
+        end
+      end
+
+      private
+
+      # Tags already applied to the target logger, so they are not duplicated.
+      # Semantic Logger exposes them via `#tags`; ActiveSupport::TaggedLogging
+      # via `formatter.current_tags`. Fall back to none when neither is present.
+      def applied_tags_for(logger)
+        if logger.respond_to?(:tags)
+          Array(logger.tags)
+        elsif logger.respond_to?(:formatter) && logger.formatter.respond_to?(:current_tags)
+          logger.formatter.current_tags
+        else
+          []
+        end
       end
     end
   end

--- a/test/extensions/action_cable/tagged_logger_proxy_test.rb
+++ b/test/extensions/action_cable/tagged_logger_proxy_test.rb
@@ -34,11 +34,70 @@ class TaggedLoggerProxyTest < Minitest::Test
     assert_equal [:user_id], logger.received_tags
   end
 
+  def test_tag_yields_when_logger_does_not_support_tagging
+    logger = Object.new
+
+    result = tagged_logger_proxy.send(:tag, logger) { :ok }
+
+    assert_equal :ok, result
+  end
+
+  # Records the full Semantic Logger severity signature so we can assert the
+  # proxy forwards payload/exception instead of dropping them (see #220).
+  class RecordingLogger
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def tags
+      []
+    end
+
+    def tagged(*)
+      yield
+    end
+
+    %i[debug info warn error fatal unknown].each do |severity|
+      define_method(severity) do |message = nil, payload = nil, exception = nil, &block|
+        @calls << [severity, message, payload, exception]
+        block&.call
+      end
+    end
+  end
+
+  def test_info_forwards_payload_to_wrapped_logger
+    logger = RecordingLogger.new
+
+    tagged_logger_proxy(logger).info("Started request", user_id: 7)
+
+    assert_equal [[:info, "Started request", {user_id: 7}, nil]], logger.calls
+  end
+
+  def test_error_forwards_exception_to_wrapped_logger
+    logger    = RecordingLogger.new
+    exception = StandardError.new("boom")
+
+    tagged_logger_proxy(logger).error("WebSocket error", nil, exception)
+
+    assert_equal [[:error, "WebSocket error", nil, exception]], logger.calls
+  end
+
+  def test_message_only_severity_still_works
+    logger = RecordingLogger.new
+
+    tagged_logger_proxy(logger).warn("Late message")
+
+    assert_equal [[:warn, "Late message", nil, nil]], logger.calls
+  end
+
   private
 
-  def tagged_logger_proxy
+  def tagged_logger_proxy(logger = nil)
     proxy = ActionCable::Connection::TaggedLoggerProxy.allocate
     proxy.singleton_class.define_method(:tags) { %i[request_id user_id] }
+    proxy.instance_variable_set(:@logger, logger) if logger
     proxy
   end
 end


### PR DESCRIPTION
## Summary

Fixes #220. Including `SemanticLogger::Loggable` in an `ActionCable::Connection::Base` subclass (or any Semantic Logger style call with a payload/exception from a connection) raised:

```
ArgumentError (wrong number of arguments (given 2, expected 0..1))
```

`ActionCable::Connection::Base` does not log through `Rails.logger` directly. It wraps the server logger in its own `TaggedLoggerProxy` (`new_tagged_logger`), and that proxy defines the severity methods (`debug`/`info`/`warn`/`error`/`fatal`/`unknown`) with a **single-arg signature** (`message = nil`). That discards Semantic Logger's richer `payload`/`exception` arguments and raises when they are supplied. Setting `server.logger` to a Semantic Logger instance is not enough because the connection re-wraps it in the proxy.

Bypassing the proxy via `new_tagged_logger` is not viable: ActionCable's worker pool calls `connection.logger.tag(ActiveRecord::Base.logger, &block)` on every job and user code calls `logger.add_tags(...)`, neither of which exist on a bare Semantic Logger logger. So the fix stays in the proxy.

## Changes

- **Forward the full Semantic Logger signature.** Redefine the proxy severity methods to forward `(message, payload, exception, &block)` to the wrapped logger while still applying the connection's tags via `tag`.
- **Reconcile `#tag` with upstream** (confirmed identical across Rails 7.2 / 8.0 / 8.1):
  - Restore the `respond_to?(:tagged)` guard with `else yield`, so a non-tagged logger handed in by the worker pool degrades cleanly instead of raising. (The previous override called `logger.tagged` unconditionally.)
  - Resolve already-applied tags from `#tags` (Semantic Logger) or `formatter.current_tags` (`ActiveSupport::TaggedLogging`), the one deliberate divergence from upstream, now documented along with the upstream source URLs for each supported version.

## Tests

Added regression coverage in `test/extensions/action_cable/tagged_logger_proxy_test.rb`:
- `info` forwards a payload
- `error` forwards an exception
- message-only severity calls still work
- `tag` yields when the target logger does not support tagging

Full suite green across the matrix (`bundle exec rake`): Rails 7.2 / 8.0 / 8.1, 0 failures, 0 errors. RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)