### PR TITLE
docs: update gemspec summary to emphasize structured + asynchronous logging

### DIFF
--- a/rails_semantic_logger.gemspec
+++ b/rails_semantic_logger.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.authors               = ["Reid Morrison"]
   s.homepage              = "https://logger.rocketjob.io"
-  s.summary               = "Feature rich logging framework that replaces the Rails logger."
+  s.summary               = "High-performance, asynchronous structured logging that replaces the Rails logger."
   s.files                 = Dir["lib/**/*", "LICENSE.txt", "Rakefile", "README.md"]
   s.license               = "Apache-2.0"
   s.required_ruby_version = ">= 3.2"


### PR DESCRIPTION
## Summary

Mirrors the tagline change in [semantic_logger#368](https://github.com/reidmorrison/semantic_logger/pull/368). Replaces the gemspec `summary`:

> ~~Feature rich logging framework that replaces the Rails logger.~~
> High-performance, asynchronous structured logging that replaces the Rails logger.

"Feature rich" was vague marketing language; "structured" and "asynchronous" are precise terms of art describing what the gem actually delivers, and improve discoverability. The Rails-specific "replaces the Rails logger" framing (the gem's whole purpose) is kept.

The README opener already reads "Rails Semantic Logger replaces the Rails default logger with Semantic Logger" and never used the "feature rich" phrasing, so no README change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)