### PR TITLE
Subscriber metrics, and consistent SemanticLogger naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - ActionView: emit a `Rendered layout` completion event (with `duration`, `allocations`, and
   `gc_time`) to mirror Rails' `render_layout` subscriber. The upstream ActionView log subscriber is
   identical across Rails 7.2 / 8.0 / 8.1, so no version-specific behavior is required.
+- ActionView: log under the name `ActionView::Base` (via `ActionView::Base.logger`) instead of
+  `ActionView`, for consistency with the `ActiveRecord::Base`, `ActiveJob::Base`,
+  `ActionMailer::Base`, and `ActionController::Base` logger names.
 - ActiveJob: add the `enqueue_retry`, `retry_stopped`, and `discard` events (present in Rails since
   before 7.2 but never reimplemented here, so they previously produced no output).
 - ActiveJob: add the Rails 8.1 Continuation events (`interrupt`, `resume`, `step_skipped`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `config.rails_semantic_logger.processing` is true, matching the `started` and `rendered` options.
 - Remove the long-deprecated and unused `named_tags` option. Supply a Hash to `config.log_tags`
   instead.
+- Metrics (prototype): emit a Semantic Logger `metric` alongside each log entry that is logged at
+  `:info`, `:warn`, or `:error`, so durations and event counts can be sent to a metrics backend.
+  Names follow `rails.<component>.<event>`, dropping the `action_`/`active_` prefix (e.g.
+  `rails.controller.process_action`, `rails.view.render.template`, `rails.job.perform`,
+  `rails.mailer.deliver`, `rails.solid_queue.start_process`). Debug-level entries (e.g.
+  ActiveRecord `sql`) carry no metric. **These metric names are a prototype and subject to change in
+  a future release.**
 
 ## [4.20.0] - 2026-04-10
 

--- a/lib/rails_semantic_logger/action_controller/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_controller/log_subscriber.rb
@@ -85,13 +85,19 @@ module RailsSemanticLogger
           {
             message:  action_message("Completed", event.payload),
             duration: event.duration,
-            payload:  payload
+            payload:  payload,
+            metric:   "rails.controller.process_action"
           }
         end
       end
 
       def halted_callback(event)
-        controller_logger(event).info { "Filter chain halted as #{event.payload[:filter].inspect} rendered or redirected" }
+        controller_logger(event).info do
+          {
+            message: "Filter chain halted as #{event.payload[:filter].inspect} rendered or redirected",
+            metric:  "rails.controller.halted_callback"
+          }
+        end
       end
 
       # Rails 8.1+ emits this event when an exception is handled by a `rescue_from` callback.
@@ -108,13 +114,17 @@ module RailsSemanticLogger
               exception:         exception.class.name,
               exception_message: exception.message,
               backtrace:         backtrace
-            }
+            },
+            metric:  "rails.controller.rescue_from_callback"
           }
         end
       end
 
       def send_file(event)
-        controller_logger(event).info(message: "Sent file", payload: {path: event.payload[:path]}, duration: event.duration)
+        controller_logger(event).info(message:  "Sent file",
+                                      payload:  {path: event.payload[:path]},
+                                      duration: event.duration,
+                                      metric:   "rails.controller.send_file")
       end
 
       def redirect_to(event)
@@ -127,13 +137,14 @@ module RailsSemanticLogger
           payload[:source] = source if source
         end
 
-        controller_logger(event).info(message: "Redirected to", payload: payload)
+        controller_logger(event).info(message: "Redirected to", payload: payload, metric: "rails.controller.redirect_to")
       end
 
       def send_data(event)
         controller_logger(event).info(message:  "Sent data",
                                       payload:  {file_name: event.payload[:filename]},
-                                      duration: event.duration)
+                                      duration: event.duration,
+                                      metric:   "rails.controller.send_data")
       end
 
       def unpermitted_parameters(event)
@@ -157,7 +168,7 @@ module RailsSemanticLogger
             return unless ::ActionController::Base.enable_fragment_cache_logging
             controller_logger(event).info do
               key_or_path = event.payload[:key] || event.payload[:path]
-              {message: "#{method.to_s.humanize} \#{key_or_path}", duration: event.duration}
+              {message: "#{method.to_s.humanize} \#{key_or_path}", duration: event.duration, metric: "rails.controller.#{method.delete('?')}"}
             end
           end
         METHOD

--- a/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_mailer/log_subscriber.rb
@@ -133,6 +133,9 @@ module RailsSemanticLogger
       def log_with_formatter(level: :info, **kw_args)
         fmt = EventFormatter.new(**kw_args)
         msg = yield fmt
+        # Emit a metric for every info/warn/error entry, named after the notification
+        # (e.g. "deliver.action_mailer" -> "rails.mailer.deliver"). Debug entries (process) are excluded.
+        msg[:metric] ||= "rails.mailer.#{kw_args[:event].name.split('.').first}" unless level == :debug
         logger.public_send(level, **msg, payload: fmt.payload)
       end
 

--- a/lib/rails_semantic_logger/action_view/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_view/log_subscriber.rb
@@ -146,7 +146,7 @@ module RailsSemanticLogger
         end
 
         def logger
-          @logger ||= SemanticLogger["ActionView"]
+          @logger ||= ::ActionView::Base.logger
         end
       end
 
@@ -163,7 +163,7 @@ module RailsSemanticLogger
 
       private
 
-      @logger             = SemanticLogger["ActionView"]
+      @logger             = ::ActionView::Base.logger
       @rendered_log_level = :debug
 
       EMPTY = "".freeze

--- a/lib/rails_semantic_logger/action_view/log_subscriber.rb
+++ b/lib/rails_semantic_logger/action_view/log_subscriber.rb
@@ -42,7 +42,8 @@ module RailsSemanticLogger
           self.class.rendered_log_level,
           "Rendered",
           payload:  payload,
-          duration: event.duration
+          duration: event.duration,
+          metric:   "rails.view.render.template"
         )
       end
 
@@ -61,7 +62,8 @@ module RailsSemanticLogger
           self.class.rendered_log_level,
           "Rendered",
           payload:  payload,
-          duration: event.duration
+          duration: event.duration,
+          metric:   "rails.view.render.partial"
         )
       end
 
@@ -78,7 +80,8 @@ module RailsSemanticLogger
           self.class.rendered_log_level,
           "Rendered layout",
           payload:  payload,
-          duration: event.duration
+          duration: event.duration,
+          metric:   "rails.view.render.layout"
         )
       end
 
@@ -99,7 +102,8 @@ module RailsSemanticLogger
           self.class.rendered_log_level,
           "Rendered",
           payload:  payload,
-          duration: event.duration
+          duration: event.duration,
+          metric:   "rails.view.render.collection"
         )
       end
 

--- a/lib/rails_semantic_logger/active_job/log_subscriber.rb
+++ b/lib/rails_semantic_logger/active_job/log_subscriber.rb
@@ -233,6 +233,7 @@ module RailsSemanticLogger
 
         logger.info(
           message: message,
+          metric:  "rails.job.enqueue_all",
           payload: {
             event_name:     event.name,
             adapter:        adapter_name,
@@ -352,6 +353,9 @@ module RailsSemanticLogger
         fmt   = EventFormatter.new(**kw_args)
         msg   = yield fmt
         extra = msg.delete(:payload) || {}
+        # Emit a metric for every info/warn/error entry, named after the notification
+        # (e.g. "enqueue.active_job" -> "rails.job.enqueue"). Debug entries are excluded.
+        msg[:metric] ||= "rails.job.#{kw_args[:event].name.split('.').first}" unless level == :debug
         logger.public_send(level, **msg, payload: fmt.payload.merge(extra))
       end
 

--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -95,7 +95,7 @@ module RailsSemanticLogger
       %i[active_record action_controller action_mailer action_view].each do |name|
         ActiveSupport.on_load(name) { include SemanticLogger::Loggable }
       end
-      ActiveSupport.on_load(:action_cable) { self.logger = SemanticLogger["ActionCable"] }
+      ActiveSupport.on_load(:action_cable) { self.logger = SemanticLogger[::ActionCable] }
     end
 
     # Before any initializers run, but after the gems have been loaded

--- a/lib/rails_semantic_logger/rack/logger.rb
+++ b/lib/rails_semantic_logger/rack/logger.rb
@@ -31,7 +31,7 @@ module RailsSemanticLogger
 
       private
 
-      @logger                    = SemanticLogger["Rack"]
+      @logger                    = SemanticLogger[::Rack]
       @started_request_log_level = :debug
 
       def call_app(request, env)

--- a/lib/rails_semantic_logger/solid_queue/log_subscriber.rb
+++ b/lib/rails_semantic_logger/solid_queue/log_subscriber.rb
@@ -164,6 +164,9 @@ module RailsSemanticLogger
         logger.public_send(level) do
           msg = {message: action, payload: attributes, duration: event.duration}
           msg[:exception] = exception if exception
+          # Emit a metric for every info/warn/error entry, named after the notification
+          # (e.g. "start_process.solid_queue" -> "rails.solid_queue.start_process"). Debug entries are excluded.
+          msg[:metric] = "rails.solid_queue.#{event.name.split('.').first}" unless level == :debug
           msg
         end
       end

--- a/lib/rails_semantic_logger/solid_queue/log_subscriber.rb
+++ b/lib/rails_semantic_logger/solid_queue/log_subscriber.rb
@@ -172,7 +172,7 @@ module RailsSemanticLogger
       end
 
       def logger
-        @logger ||= SemanticLogger["SolidQueue"]
+        @logger ||= SemanticLogger[::SolidQueue]
       end
     end
   end

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -46,6 +46,51 @@ class ActionControllerTest < Minitest::Test
         assert_instance_of Float, payload[:cpu_time]
         assert_instance_of Float, payload[:idle_time]
       end
+
+      it "emits the rails.controller.process_action metric" do
+        event = ActiveSupport::Notifications::Event.new(
+          "process_action.action_controller",
+          5.seconds.ago,
+          Time.zone.now,
+          SecureRandom.uuid,
+          {
+            controller: "ArticlesController",
+            action:     "index",
+            status:     200
+          }
+        )
+
+        messages = semantic_logger_events do
+          subscriber.process_action(event)
+        end
+
+        assert_equal 1, messages.count, messages
+        assert_equal "rails.controller.process_action", messages[0].metric
+      end
+    end
+
+    describe "#redirect_to" do
+      it "emits the rails.controller.redirect_to metric" do
+        event = ActiveSupport::Notifications::Event.new(
+          "redirect_to.action_controller",
+          5.seconds.ago,
+          Time.zone.now,
+          SecureRandom.uuid,
+          {location: "https://example.com/", request: nil}
+        )
+
+        messages = semantic_logger_events do
+          subscriber.redirect_to(event)
+        end
+
+        assert_equal 1, messages.count, messages
+        assert_semantic_logger_event(
+          messages[0],
+          level:   :info,
+          message: "Redirected to",
+          metric:  "rails.controller.redirect_to"
+        )
+      end
     end
 
     describe "#start_processing" do

--- a/test/action_mailer_test.rb
+++ b/test/action_mailer_test.rb
@@ -78,7 +78,8 @@ class ActionMailerTest < Minitest::Test
           assert_semantic_logger_event(
             events.first,
             level:            :info,
-            message_includes: "Delivered mail <abc@mail>"
+            message_includes: "Delivered mail <abc@mail>",
+            metric:           "rails.mailer.deliver"
           )
         end
 
@@ -106,7 +107,8 @@ class ActionMailerTest < Minitest::Test
             events.first,
             level:            :error,
             message_includes: "Error delivering mail <abc@mail>",
-            exception:        exception
+            exception:        exception,
+            metric:           "rails.mailer.deliver"
           )
         end
 
@@ -141,6 +143,8 @@ class ActionMailerTest < Minitest::Test
             level:            :debug,
             message_includes: "MyMailer#some_email: processed outbound mail"
           )
+          # process logs at :debug, so it carries no metric.
+          assert_nil events.first.metric
         end
 
         it "is silenced when the logger level is above debug" do

--- a/test/action_view_test.rb
+++ b/test/action_view_test.rb
@@ -13,7 +13,7 @@ class ActionViewTest < ActionDispatch::IntegrationTest
         # The block stands in for the actual view render the notification wraps.
         ActiveSupport::Notifications.instrument("#{name}.action_view", payload) { :rendered }
       end
-      events.select { |m| m.name == "ActionView" }
+      events.select { |m| m.name == "ActionView::Base" }
     end
 
     def view_path(relative)
@@ -144,7 +144,7 @@ class ActionViewTest < ActionDispatch::IntegrationTest
 
     describe "rendering a template within a layout (integration)" do
       def action_view_events(messages)
-        messages.select { |m| m.name == "ActionView" }
+        messages.select { |m| m.name == "ActionView::Base" }
       end
 
       it "logs the layout and template render" do

--- a/test/action_view_test.rb
+++ b/test/action_view_test.rb
@@ -30,6 +30,7 @@ class ActionViewTest < ActionDispatch::IntegrationTest
 
         assert_equal "Rendered", rendered.message
         assert_equal :debug, rendered.level
+        assert_equal "rails.view.render.partial", rendered.metric
         assert_equal "articles/_form.html.erb", rendered.payload[:partial]
         assert_kind_of Integer, rendered.payload[:allocations]
         assert_kind_of Float, rendered.payload[:gc_time]
@@ -85,6 +86,7 @@ class ActionViewTest < ActionDispatch::IntegrationTest
 
         assert_equal "Rendered", rendered.message
         assert_equal :debug, rendered.level
+        assert_equal "rails.view.render.collection", rendered.metric
         assert_equal "articles/_article.html.erb", rendered.payload[:template]
         assert_equal 3, rendered.payload[:count]
         assert_equal 2, rendered.payload[:cache_hits]
@@ -118,10 +120,25 @@ class ActionViewTest < ActionDispatch::IntegrationTest
         rendered = events.find { |m| m.message == "Rendered" }
 
         assert rendered, events
+        assert_equal "rails.view.render.template", rendered.metric
         assert_equal "welcome/index.html.erb", rendered.payload[:template]
         assert_equal "layouts/application.html.erb", rendered.payload[:within]
         assert_kind_of Integer, rendered.payload[:allocations]
         assert_kind_of Float, rendered.payload[:gc_time]
+      end
+    end
+
+    describe "#render_layout" do
+      it "emits the rails.view.render.layout metric" do
+        # render_layout.action_view also drives the Start subscriber, which emits a "Rendering layout"
+        # event before the "Rendered layout" completion handled here.
+        events = instrument("render_layout", identifier: view_path("layouts/application.html.erb"))
+
+        rendered = events.find { |m| m.message == "Rendered layout" }
+
+        assert rendered, events
+        assert_equal "rails.view.render.layout", rendered.metric
+        assert_equal "layouts/application.html.erb", rendered.payload[:template]
       end
     end
 

--- a/test/active_job_test.rb
+++ b/test/active_job_test.rb
@@ -108,6 +108,7 @@ class ActiveJobTest < Minitest::Test
             level:            :error,
             name:             "Rails",
             message_includes: "Error performing ActiveJobTest::MyJob",
+            metric:           "rails.job.perform",
             payload_includes: {
               job_class:  "ActiveJobTest::MyJob",
               queue:      "my_jobs",
@@ -146,6 +147,7 @@ class ActiveJobTest < Minitest::Test
             level:            :error,
             name:             "Rails",
             message_includes: "Failed enqueuing ActiveJobTest::MyJob",
+            metric:           "rails.job.enqueue",
             payload_includes: {
               job_class:  "ActiveJobTest::MyJob",
               queue:      "my_jobs",
@@ -218,6 +220,7 @@ class ActiveJobTest < Minitest::Test
             level:            :error,
             name:             "Rails",
             message_includes: "Failed enqueuing ActiveJobTest::MyJob",
+            metric:           "rails.job.enqueue",
             payload_includes: {
               job_class:  "ActiveJobTest::MyJob",
               queue:      "my_jobs",
@@ -300,6 +303,7 @@ class ActiveJobTest < Minitest::Test
             level:            :info,
             name:             "Rails",
             message_includes: "Enqueued 2 jobs to Inline",
+            metric:           "rails.job.enqueue_all",
             payload_includes: {
               adapter:        "Inline",
               enqueued_count: 2,

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -48,7 +48,7 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
         assert_semantic_logger_event(
           messages[2],
           message: "Rendering",
-          name:    "ActionView",
+          name:    "ActionView::Base",
           level:   :debug,
           payload: {
             template: "text template"
@@ -58,7 +58,7 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
         assert_semantic_logger_event(
           messages[3],
           message: "Rendered",
-          name:    "ActionView",
+          name:    "ActionView::Base",
           level:   :debug
         )
 

--- a/test/solid_queue_test.rb
+++ b/test/solid_queue_test.rb
@@ -36,6 +36,8 @@ class SolidQueueTest < Minitest::Test
             size:            3
           }
         )
+        # Debug events carry no metric.
+        assert_nil messages[0].metric
       end
     end
 
@@ -55,6 +57,7 @@ class SolidQueueTest < Minitest::Test
           level:            :info,
           name:             "SolidQueue",
           message:          "Release claimed jobs",
+          metric:           "rails.solid_queue.release_many_claimed",
           payload_includes: {size: 5}
         )
       end
@@ -75,7 +78,8 @@ class SolidQueueTest < Minitest::Test
           messages[0],
           level:   :warn,
           name:    "SolidQueue",
-          message: "Fail claimed jobs"
+          message: "Fail claimed jobs",
+          metric:  "rails.solid_queue.fail_many_claimed"
         )
       end
     end
@@ -95,7 +99,8 @@ class SolidQueueTest < Minitest::Test
           messages[0],
           level:   :error,
           name:    "SolidQueue",
-          message: "Error in thread"
+          message: "Error in thread",
+          metric:  "rails.solid_queue.thread_error"
         )
 
         exception = messages[0].exception
@@ -157,6 +162,8 @@ class SolidQueueTest < Minitest::Test
             message:          "Enqueued recurring task",
             payload_includes: {task: "my_task", active_job_id: "job-1"}
           )
+          # The debug success branch carries no metric, unlike the error branch.
+          assert_nil messages[0].metric
         end
       end
 
@@ -175,6 +182,7 @@ class SolidQueueTest < Minitest::Test
             level:            :error,
             name:             "SolidQueue",
             message:          "Error enqueuing recurring task",
+            metric:           "rails.solid_queue.enqueue_recurring_task",
             payload_includes: {task: "my_task", enqueue_error: "boom"}
           )
         end


### PR DESCRIPTION
## Summary

Two related sets of changes to the Rails log subscribers:

### 1. Prototype metrics

Attach a Semantic Logger `metric` to each Rails log subscriber entry that is logged at `:info`, `:warn`, or `:error`, so durations and event counts can be forwarded to a metrics backend alongside the structured logs. When the entry carries a duration the metric records that timing; otherwise it acts as an event counter.

Metric names follow `rails.<component>.<event>`, dropping the `action_`/`active_` prefix:

| Component | Metrics |
| --- | --- |
| Action Controller | `rails.controller.process_action`, `.send_file`, `.send_data`, `.redirect_to`, `.halted_callback`, `.rescue_from_callback`, and the fragment-cache events (`.write_fragment`, `.read_fragment`, `.exist_fragment`, `.expire_fragment`, `.expire_page`, `.write_page`) |
| Action View | `rails.view.render.{template,partial,layout,collection}` |
| Active Job | `rails.job.<event>` for every job event (enqueue, perform, step, ...) |
| Action Mailer | `rails.mailer.deliver` |
| Solid Queue | `rails.solid_queue.<event>` for every info/warn/error event |

Debug-level entries (e.g. ActiveRecord `sql`) carry **no** metric. Action View render metrics are emitted at the configured `rendered_log_level` (debug by default; raised to info via `config.rails_semantic_logger.rendered`).

Notes:
- For ActiveJob, ActionMailer, and SolidQueue the rule is encoded once in each subscriber's shared emit helper (derives the name from the notification, skips `:debug`), so new events follow the standard automatically. ActionController names each metric explicitly per method.
- **These metric names are a prototype and subject to change** in a future release.
- Docs for this gem live in the `semantic_logger` repo; a companion PR adds a "Metrics (prototype)" section to `docs/rails.md`.

### 2. Consistent logger naming

- **Action View now logs under `ActionView::Base`** (via `ActionView::Base.logger`) instead of `ActionView`, matching the `ActiveRecord::Base`, `ActiveJob::Base`, `ActionMailer::Base`, and `ActionController::Base` logger names. ActionCable keeps the name `ActionCable` because it has no single `::Base` class.
- **Pass class/module constants to `SemanticLogger[]` instead of strings** where possible: the remaining string lookups (`"ActionCable"`, `"SolidQueue"`, `"Rack"`) now use the top-level constants `::ActionCable`, `::SolidQueue`, and `::Rack`. The `::` prefix is required because the enclosing `RailsSemanticLogger` namespace defines shadowing modules of the same name. No `defined?` guards were added: each lookup runs in a context where the constant is guaranteed loaded (the `on_load(:action_cable)` hook, a subscriber only attached when SolidQueue is present, and Rack as a hard dependency). The engine's optional-integration lookups (Mongoid, Sidekiq, etc.) already pass constants behind `defined?` guards.

## Testing

- Added metric assertions to the affected subscriber tests (and `assert_nil` checks confirming debug entries carry no metric); updated logger-name assertions to `ActionView::Base`.
- `rake test` (current Gemfile): 198 runs, 922 assertions, 0 failures.
- `rubocop`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)