### PR TITLE
Stop hijacking ActiveSupport::Logger.new when a destination is given (#141)

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -113,7 +113,7 @@ module RailsSemanticLogger
       Mongo::Logger.logger = SemanticLogger[Mongo] if defined?(Mongo::Logger)
 
       # Replace the Resque Logger
-      Resque.logger        = SemanticLogger[Resque] if defined?(Resque) && Resque.respond_to?(:logger=)
+      Resque.logger = SemanticLogger[Resque] if defined?(Resque) && Resque.respond_to?(:logger=)
 
       # Replace the Sidekiq logger
       if config.rails_semantic_logger.replace_sidekiq_logger && defined?(::Sidekiq)

--- a/lib/rails_semantic_logger/extensions/active_support/logger.rb
+++ b/lib/rails_semantic_logger/extensions/active_support/logger.rb
@@ -1,27 +1,36 @@
 require "active_support/logger"
 
 module ActiveSupport
-  # More hacks to try and stop Rails from being it's own worst enemy.
+  # More hacks to try and stop Rails from being its own worst enemy.
   class Logger
     class << self
+      # Keep a handle on the genuine constructor so that callers which supply a
+      # real log destination still get a real logger (see #new below).
+      alias _semantic_logger_original_new new
+
       undef :logger_outputs_to?
 
-      # Prevent broadcasting since SemanticLogger already supports multiple loggers
-      if method_defined?(:broadcast)
-        undef :broadcast
-        def broadcast(_logger)
-          Module.new
+      # Prevent Rails from trying to merge/broadcast loggers (e.g. ActiveRecord's
+      # `console` hook and `rails server`'s log_to_stdout). SemanticLogger already
+      # multiplexes through its own appenders, and SemanticLogger::Logger does not
+      # implement #broadcast_to, so the merge path would otherwise raise.
+      def logger_outputs_to?(*_args)
+        true
+      end
+
+      # Historically every `ActiveSupport::Logger.new(...)` call was redirected to
+      # SemanticLogger, silently discarding the requested destination. That broke
+      # third-party callers such as Webpacker's `ActiveSupport::Logger.new(STDOUT)`,
+      # whose output never reached STDOUT (issue #141). Only redirect to
+      # SemanticLogger when no destination is supplied; otherwise honor the caller
+      # and build a genuine logger pointed at the requested destination.
+      def new(*args, **kwargs)
+        if args.empty? && kwargs.empty?
+          SemanticLogger[self]
+        else
+          _semantic_logger_original_new(*args, **kwargs)
         end
       end
-    end
-
-    # Prevent Console from trying to merge loggers
-    def self.logger_outputs_to?(*_args)
-      true
-    end
-
-    def self.new(*_args, **_kwargs)
-      SemanticLogger[self]
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #141. `ActiveSupport::Logger.new(...)` was unconditionally overridden to return a `SemanticLogger` logger, **silently discarding the destination argument**. Third-party callers such as Webpacker's `ActiveSupport::Logger.new(STDOUT)` therefore got a logger that never wrote to STDOUT.

This PR scopes the override so it only hijacks the no-argument case and otherwise builds a genuine logger pointed at the requested destination.

## Changes

- **`self.new` is now scoped** — returns `SemanticLogger[self]` only when called with no destination; when an IO/file is passed it delegates to the original constructor (captured via `alias`), so the caller gets a real logger that writes where it asked.
- **Removed the dead `broadcast` override** — the `broadcast` class method was dropped from `ActiveSupport::Logger` in Rails 7.1 (replaced by `BroadcastLogger`), so the `method_defined?(:broadcast)` branch never applied on any supported version (7.2 / 8.0 / 8.1).
- **Kept `logger_outputs_to? -> true`** — this is load-bearing. Without it, ActiveRecord's `console` hook hits `Rails.logger.broadcast_to(...)`, which `SemanticLogger::Logger` does not implement, raising `NoMethodError` when starting `rails console`. Verified empirically.
- Minor unrelated whitespace fix in `engine.rb`.

## Testing

- `rake test` green on Rails 8.0 (198 runs, 0 failures) and 8.1 (198 runs, 0 failures).
- Verified directly: `ActiveSupport::Logger.new(io)` now returns a real `ActiveSupport::Logger` that writes to the supplied IO; no-arg `.new` still returns `SemanticLogger`; the `rails console` `broadcast_to` path no longer raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)