### PR TITLE
Fix SolidQueue reopen hooks never registering (constant resolution)

### DIFF
--- a/lib/rails_semantic_logger/engine.rb
+++ b/lib/rails_semantic_logger/engine.rb
@@ -269,10 +269,10 @@ module RailsSemanticLogger
       Spring.after_fork { |_job| ::SemanticLogger.reopen } if defined?(Spring.after_fork)
 
       # Re-open appenders after SolidQueue worker/dispatcher/scheduler has finished booting
-      SolidQueue.on_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_start)
-      SolidQueue.on_worker_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_worker_start)
-      SolidQueue.on_dispatcher_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_dispatcher_start)
-      SolidQueue.on_scheduler_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_scheduler_start)
+      ::SolidQueue.on_start { ::SemanticLogger.reopen } if defined?(::SolidQueue.on_start)
+      ::SolidQueue.on_worker_start { ::SemanticLogger.reopen } if defined?(::SolidQueue.on_worker_start)
+      ::SolidQueue.on_dispatcher_start { ::SemanticLogger.reopen } if defined?(::SolidQueue.on_dispatcher_start)
+      ::SolidQueue.on_scheduler_start { ::SemanticLogger.reopen } if defined?(::SolidQueue.on_scheduler_start)
 
       console do |_app|
         # Don't use a background thread for logging


### PR DESCRIPTION
## Problem

The SolidQueue fork-handling hooks in `engine.rb` never register:

```ruby
SolidQueue.on_worker_start { ::SemanticLogger.reopen } if defined?(SolidQueue.on_worker_start)
```

Inside `RailsSemanticLogger::Engine`, the bare `SolidQueue` constant resolves lexically to the gem's own `RailsSemanticLogger::SolidQueue` namespace (defined in `rails_semantic_logger.rb` for the log subscriber), not to `::SolidQueue`. Since `on_start`/`on_worker_start`/etc. don't exist on that module, every `defined?(SolidQueue.on_*)` guard returns `nil` and all four registrations are silently skipped.

## Impact

Processes forked by the Solid Queue supervisor inherit a dead SemanticLogger appender thread. Log messages accumulate in the capped 10,000-entry queue with nothing draining it, and once full, every thread that logs blocks forever in `SizedQueue#push`. Jobs then hang indefinitely (worker heartbeats keep running, so Solid Queue never releases the claims), and `Timeout.timeout` can't interrupt a push that happens outside the timeout block.

We debugged this in production: rbtrace showed all worker threads parked in `SizedQueue#push`, the processor thread dead, the queue at 10,000/10,000, and `SolidQueue::Worker.lifecycle_hooks[:start]` empty despite this engine code having run (the `RailsSemanticLogger::SolidQueue::LogSubscriber` swap directly above it had executed).

## Fix

Prefix the four references with `::` so they resolve to the real `SolidQueue` module, matching the explicit `::SolidQueue::LogSubscriber` reference used earlier in the same file.