### PR TITLE
Correct add_server comments: rack servers are not auto-detected

### DIFF
--- a/lib/rails_semantic_logger/appenders.rb
+++ b/lib/rails_semantic_logger/appenders.rb
@@ -16,8 +16,8 @@ module RailsSemanticLogger
   # destination and formatting are ordinary `SemanticLogger.add_appender` arguments:
   #
   #   #add         - always created, during Rails initialization.
-  #   #add_server  - created only when serving requests (`rails server`, a rack
-  #                  server, Sidekiq in server mode). Defaults to `$stdout`.
+  #   #add_server  - created only when serving requests (`rails server`, Sidekiq
+  #                  in server mode). Defaults to `$stdout`.
   #   #add_console - created only inside a `rails console` session. Defaults to
   #                  `$stderr` so log output does not tangle with command results.
   #
@@ -44,9 +44,10 @@ module RailsSemanticLogger
     end
 
     # Declare an appender that is only created when the application is serving
-    # requests: `rails server`, a rack server started directly (puma, etc.), or
-    # Sidekiq in server mode. It is never created during a non-serving boot (rake
-    # tasks, runners, generators), so it only appears where it is useful.
+    # requests: `rails server`, Sidekiq in server mode, or when the app calls
+    # RailsSemanticLogger.add_server_appenders from its own server's boot hook.
+    # It is never created during a non-serving boot (rake tasks, runners,
+    # generators), so it only appears where it is useful.
     #
     # Accepts the same arguments (and optional block) as SemanticLogger.add_appender.
     # When no destination is given it defaults to `$stdout`; the formatter defaults

--- a/lib/rails_semantic_logger/options.rb
+++ b/lib/rails_semantic_logger/options.rb
@@ -181,7 +181,7 @@ module RailsSemanticLogger
     # The method names the context in which the appender is created; the destination
     # is an ordinary `SemanticLogger.add_appender` argument. Use `add` for an
     # appender that is always created, `add_server` for one created only when serving
-    # requests (`rails server`, a rack server, Sidekiq in server mode; defaults to
+    # requests (`rails server`, Sidekiq in server mode; defaults to
     # `$stdout`), and `add_console` for one created only inside a `rails console`
     # session (defaults to `$stderr`). Any appender works in any context, so a
     # context may declare several (e.g. a server-only stdout and file appender).


### PR DESCRIPTION
While reviewing the rails.md docs for accuracy, the source comments in `Appenders` and `Options` turned out to have the same inaccuracy being fixed in the docs: they listed "a rack server" as a context where `add_server` appenders are created automatically.

Only two contexts are actually detected: `rails server` (via the `Rails::Server#log_to_stdout` patch) and Sidekiq in server mode. App servers started directly (bare `puma`, `rackup`, Passenger, Unicorn) are deliberately not detected; those apps call `RailsSemanticLogger.add_server_appenders` from the server's own boot hook, which the `Appenders#add_server` comment now mentions.

Comment-only change; no behavior affected. The corresponding rails.md updates in the semantic_logger repo are handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)