### PR TITLE
Fix TaggedLoggerProxy ArgumentError when wrapped logger is a plain Ruby Logger

### DIFF
--- a/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
+++ b/lib/rails_semantic_logger/extensions/action_cable/tagged_logger_proxy.rb
@@ -30,11 +30,28 @@ module ActionCable
       # wrapped logger, while still applying the connection's tags. See #220.
       %i[debug info warn error fatal unknown].each do |severity|
         define_method(severity) do |message = nil, payload = nil, exception = nil, &block|
-          tag(@logger) { @logger.public_send(severity, message, payload, exception, &block) }
+          tag(@logger) { forward(severity, message, payload, exception, &block) }
         end
       end
 
       private
+
+      # Only forward the extra payload/exception arguments when the wrapped logger's
+      # method can accept them. A standard Ruby Logger (e.g. the one wrapped by
+      # ActionCable::Connection::TestCase) only accepts a single `progname` argument
+      # and raises ArgumentError given more, so fall back to the single-arg call. See #317.
+      def forward(severity, message, payload, exception, &)
+        if extended_signature?(@logger, severity)
+          @logger.public_send(severity, message, payload, exception, &)
+        else
+          @logger.public_send(severity, message, &)
+        end
+      end
+
+      def extended_signature?(logger, severity)
+        params = logger.method(severity).parameters
+        params.any? { |type, _| type == :rest } || params.count { |type, _| %i[req opt].include?(type) } >= 3
+      end
 
       # Tags already applied to the target logger, so they are not duplicated.
       # Semantic Logger exposes them via `#tags`; ActiveSupport::TaggedLogging

--- a/test/extensions/action_cable/tagged_logger_proxy_test.rb
+++ b/test/extensions/action_cable/tagged_logger_proxy_test.rb
@@ -92,6 +92,17 @@ class TaggedLoggerProxyTest < Minitest::Test
     assert_equal [[:warn, "Late message", nil, nil]], logger.calls
   end
 
+  # A standard Ruby Logger (e.g. wrapped by ActionCable::Connection::TestCase) only
+  # accepts a single `progname` argument and raises ArgumentError given more. See #317.
+  def test_plain_ruby_logger_does_not_raise
+    io     = StringIO.new
+    logger = Logger.new(io)
+
+    tagged_logger_proxy(logger).error("An unauthorized connection attempt was rejected")
+
+    assert_match(/An unauthorized connection attempt was rejected/, io.string)
+  end
+
   private
 
   def tagged_logger_proxy(logger = nil)


### PR DESCRIPTION
## Summary
- The `TaggedLoggerProxy` patch added in 5.0.0 (#220) unconditionally forwards Semantic Logger's `(message, payload, exception)` signature to whatever logger it wraps.
- A standard Ruby `Logger` (e.g. the one `ActionCable::Connection::TestCase` wraps) only accepts a single `progname` argument and raises `ArgumentError: wrong number of arguments (given 3, expected 0..1)` when given more — breaking `ActionCable::Connection::TestCase` specs (e.g. `have_rejected_connection`).
- Now inspects the wrapped logger's method signature (`Method#parameters`) and only forwards the extra `payload`/`exception` args when the target can accept them (Semantic Logger, or a compatible test double); otherwise falls back to the single-arg call, matching pre-5.0.0/upstream Rails behavior.

Fixes #317

## Test plan
- [x] Added `test_plain_ruby_logger_does_not_raise` reproducing the issue with a real stdlib `Logger`
- [x] `bundle exec ruby -Itest test/extensions/action_cable/tagged_logger_proxy_test.rb` — 7 runs, 0 failures
- [x] `bundle exec rake test` — 199 runs, 0 failures
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)