### PR TITLE
Exercise the quiet_assets code path under CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,6 @@ Tests run against a full dummy Rails app in `test/dummy/` (controllers, models, 
 
 ## Known tech debt
 
-- **The `quiet_assets` code path is unexercised in tests.** The dummy app has no sprockets-rails, so `config.assets` does not exist in the test environment and the asset-silencing filter in the engine never runs under CI.
 - **The engine's boot-time rescue only catches synchronous appender-creation errors.** A file appender pointing at an uncreatable path does not raise when created; the failure surfaces asynchronously in semantic_logger's queue processor on first write, so the engine's rescue (degrade to STDERR at warn) never runs and the app boots with a silently broken appender. Catching this would need help from semantic_logger (e.g. an eager open/validate at creation time).
 
 ## Conventions

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -36,5 +36,13 @@ module Dummy
 
     # Test out Amazing Print
     config.rails_semantic_logger.ap_options = {multiline: false, ruby19_syntax: true}
+
+    # Simulate an asset pipeline gem (sprockets-rails/propshaft both expose config.assets
+    # with #quiet/#prefix) without adding the real gem, so the engine's quiet_assets
+    # detection and asset-silencing filter - otherwise dormant - run under CI.
+    config.assets            = ActiveSupport::OrderedOptions.new
+    config.assets.quiet      = true
+    config.assets.prefix     = "/assets"
+    config.assets.precompile = []
   end
 end

--- a/test/quiet_assets_test.rb
+++ b/test/quiet_assets_test.rb
@@ -1,0 +1,33 @@
+require_relative "test_helper"
+
+class QuietAssetsTest < Minitest::Test
+  describe "quiet_assets" do
+    it "derives config.rails_semantic_logger.quiet_assets from config.assets.quiet" do
+      assert Rails.application.config.rails_semantic_logger.quiet_assets
+    end
+
+    it "clears config.assets.quiet so Sprockets can find the Rack::Logger middleware" do
+      refute Rails.application.config.assets.quiet
+    end
+
+    it "installs a filter on the Rack logger that silences asset requests" do
+      filter = RailsSemanticLogger::Rack::Logger.logger.filter
+
+      refute_nil filter
+
+      log         = SemanticLogger::Log.new("Rack", :info)
+      log.payload = {path: "/assets/application-abc123.js"}
+
+      refute filter.call(log)
+    end
+
+    it "does not silence non-asset requests" do
+      filter = RailsSemanticLogger::Rack::Logger.logger.filter
+
+      log         = SemanticLogger::Log.new("Rack", :info)
+      log.payload = {path: "/welcome/index"}
+
+      assert filter.call(log)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- CLAUDE.md flagged that the `quiet_assets` code path (asset-request log silencing) was unexercised in tests because the dummy app has no asset pipeline gem, so `config.assets` never existed.
- Adds a minimal `config.assets` double in the dummy app (`quiet`/`prefix`/`precompile`, matching the surface sprockets-rails/propshaft would provide) so the engine's `before_initialize` detection and `after_initialize` log filter actually run during boot.
- Adds `test/quiet_assets_test.rb` asserting `quiet_assets` is derived from `config.assets.quiet`, `config.assets.quiet` is reset to `false`, and the installed filter silences `/assets/...` paths while leaving other paths alone.
- Removes the now-resolved bullet from CLAUDE.md's "Known tech debt" section.

## Test plan
- [x] `bundle exec ruby -Itest test/quiet_assets_test.rb`
- [x] `bundle exec rake test` (full suite, default Gemfile)
- [x] `bundle exec appraisal rails_7.2 rake test`
- [x] `bundle exec appraisal rails_8.0 rake test`
- [x] `bundle exec rubocop test/quiet_assets_test.rb test/dummy/config/application.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)